### PR TITLE
Pitest improvements

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -103,7 +103,15 @@
               <mutator>NON_VOID_METHOD_CALLS</mutator>
               <mutator>REMOVE_CONDITIONALS</mutator>
             </mutators>
-            <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
+            <avoidCallsTo>
+              <!--
+                String concatenation ("a" + "b") is implemented using StringBuilder.append() in bytecode.
+                We're not interested in mutations of these calls - it's mostly toString() and exception messages.
+                Reducing number of mutations also improves execution time.
+              -->
+              <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
+              <avoidCallsTo>org.slf4j</avoidCallsTo>
+            </avoidCallsTo>
           </configuration>
         </plugin>
       </plugins>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -112,6 +112,9 @@
               <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
               <avoidCallsTo>org.slf4j</avoidCallsTo>
             </avoidCallsTo>
+            <excludedTestClasses>
+              org.optaweb.vehiclerouting.plugin.persistence.integration_tests.*
+            </excludedTestClasses>
           </configuration>
         </plugin>
       </plugins>

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceEntity.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceEntity.java
@@ -41,6 +41,10 @@ public class DistanceEntity {
         this.distance = Objects.requireNonNull(distance);
     }
 
+    DistanceKey getKey() {
+        return key;
+    }
+
     public Double getDistance() {
         return distance;
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceKey.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceKey.java
@@ -40,6 +40,14 @@ public class DistanceKey implements Serializable {
         this.toId = toId;
     }
 
+    Long getFromId() {
+        return fromId;
+    }
+
+    Long getToId() {
+        return toId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LatLngTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LatLngTest.java
@@ -33,9 +33,30 @@ public class LatLngTest {
 
     @Test
     public void latngs_should_be_equals_when_numerically_equal() {
+        LatLng latLng = new LatLng(BigDecimal.valueOf(987.1234), BigDecimal.valueOf(-0.1111));
+        assertThat(latLng).isEqualTo(latLng);
+
         BigDecimal ONE_POINT_ZERO = new BigDecimal("1.0");
         BigDecimal MINUS_ZERO = BigDecimal.ZERO.negate();
-        assertThat(new LatLng(MINUS_ZERO, ONE_POINT_ZERO))
-                .isEqualTo(new LatLng(BigDecimal.ZERO, BigDecimal.ONE));
+        assertThat(new LatLng(MINUS_ZERO, ONE_POINT_ZERO)).isEqualTo(new LatLng(BigDecimal.ZERO, BigDecimal.ONE));
+        assertThat(new LatLng(ONE_POINT_ZERO, MINUS_ZERO)).isEqualTo(new LatLng(BigDecimal.ONE, BigDecimal.ZERO));
+    }
+
+    @Test
+    public void should_not_equal() {
+        LatLng latLng = new LatLng(BigDecimal.ONE, BigDecimal.TEN);
+        assertThat(latLng).isNotEqualTo(null);
+        assertThat(latLng).isNotEqualTo(BigDecimal.valueOf(11));
+        assertThat(latLng).isNotEqualTo(new LatLng(BigDecimal.ONE, BigDecimal.ONE));
+        assertThat(latLng).isNotEqualTo(new LatLng(BigDecimal.TEN, BigDecimal.TEN));
+    }
+
+    @Test
+    public void value_of_and_getters() {
+        double latitude = Math.E;
+        double longitude = Math.PI;
+        LatLng latLng = LatLng.valueOf(latitude, longitude);
+        assertThat(latLng.getLatitude()).isEqualTo(BigDecimal.valueOf(latitude));
+        assertThat(latLng.getLongitude()).isEqualTo(BigDecimal.valueOf(longitude));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LocationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LocationTest.java
@@ -43,6 +43,10 @@ public class LocationTest {
         assertThat(location).isNotEqualTo(new Location(0, latLng1));
         // null
         assertThat(location).isNotEqualTo(null);
+        // different class
+        assertThat(location).isNotEqualTo(latLng0);
+        // same object -> OK
+        assertThat(location).isEqualTo(location);
         // same properties -> OK
         assertThat(location).isEqualTo(new Location(0, latLng0));
     }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceEntityTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceEntityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.persistence;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DistanceEntityTest {
+
+    @Test
+    public void constructor_params_must_not_be_null() {
+        DistanceKey dKey = new DistanceKey(1, 2);
+        assertThatThrownBy(() -> new DistanceEntity(null, 10.0)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new DistanceEntity(dKey, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void equals() {
+        final long from = 10;
+        final long to = 2000;
+        final DistanceKey distanceKey = new DistanceKey(from, to);
+        final double distance = 5.0001;
+
+        DistanceEntity distanceEntity = new DistanceEntity(distanceKey, distance);
+        assertThat(distanceEntity).isEqualTo(distanceEntity);
+        assertThat(distanceEntity).isEqualTo(new DistanceEntity(new DistanceKey(from, to), distance));
+
+        assertThat(distanceEntity).isNotEqualTo(null);
+        assertThat(distanceEntity).isNotEqualTo(distanceKey);
+        assertThat(distanceEntity).isNotEqualTo(new DistanceEntity(distanceKey, distance + 1));
+        assertThat(distanceEntity).isNotEqualTo(new DistanceEntity(new DistanceKey(to, from), distance));
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationEntityTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationEntityTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.persistence;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LocationEntityTest {
+
+    @Test
+    public void constructor_params_must_not_be_null() {
+        assertThatThrownBy(() -> new LocationEntity(null, BigDecimal.ZERO)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new LocationEntity(BigDecimal.ZERO, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void getters() {
+        BigDecimal latitude = BigDecimal.valueOf(0.101);
+        BigDecimal longitude = BigDecimal.valueOf(101.0);
+        LocationEntity locationEntity = new LocationEntity(latitude, longitude);
+        assertThat(locationEntity.getId()).isZero();
+        assertThat(locationEntity.getLongitude()).isEqualTo(longitude);
+        assertThat(locationEntity.getLatitude()).isEqualTo(latitude);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryImplTest.java
@@ -17,63 +17,70 @@
 package org.optaweb.vehiclerouting.plugin.persistence;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.optaweb.vehiclerouting.domain.LatLng;
 import org.optaweb.vehiclerouting.domain.Location;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@DataJpaTest
-@RunWith(SpringRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class LocationRepositoryImplTest {
 
-    @Autowired
+    @Mock
     private LocationCrudRepository crudRepository;
+    @InjectMocks
     private LocationRepositoryImpl repository;
+    @Mock
+    private LocationEntity locationEntity;
+    private Location testLocation;
 
     @Before
     public void setUp() {
-        repository = new LocationRepositoryImpl(crudRepository);
+        final long id = 76;
+        final BigDecimal latitude = BigDecimal.valueOf(1.2);
+        final BigDecimal longitude = BigDecimal.valueOf(3.4);
+        testLocation = new Location(id, new LatLng(latitude, longitude));
+        when(locationEntity.getId()).thenReturn(id);
+        when(locationEntity.getLatitude()).thenReturn(latitude);
+        when(locationEntity.getLongitude()).thenReturn(longitude);
     }
 
     @Test
-    public void db_schema() {
-        // https://wiki.openstreetmap.org/wiki/Node#Structure
-        final BigDecimal maxLatitude = new BigDecimal("90.0000000");
-        final BigDecimal maxLongitude = new BigDecimal("214.7483647");
-        final BigDecimal minLatitude = maxLatitude.negate();
-        final BigDecimal minLongitude = maxLongitude.negate();
+    public void should_create_location_and_generate_id() {
+        when(crudRepository.save(any(LocationEntity.class))).thenReturn(locationEntity);
 
-        LocationEntity minLocation = new LocationEntity(minLatitude, minLongitude);
-        LocationEntity maxLocation = new LocationEntity(maxLatitude, maxLongitude);
-        crudRepository.save(minLocation);
-        crudRepository.save(maxLocation);
-
-        assertThat(crudRepository.findById(minLocation.getId())).get().isEqualTo(minLocation);
-        assertThat(crudRepository.findById(maxLocation.getId())).get().isEqualTo(maxLocation);
-    }
-
-    @Test
-    public void remove_created_location() {
         LatLng latLng = LatLng.valueOf(0.00213, 32.777);
-        assertThat(crudRepository.count()).isZero();
-        Location location = repository.createLocation(latLng);
-        assertThat(location.getLatLng()).isEqualTo(latLng);
-        assertThat(crudRepository.count()).isOne();
+        Location createdLocation = repository.createLocation(latLng);
+        assertThat(createdLocation.getId()).isEqualTo(testLocation.getId());
+        assertThat(createdLocation.getLatLng()).isEqualTo(latLng);
+    }
 
-        Location removed = repository.removeLocation(location.getId());
-        assertThat(removed).isEqualTo(location);
+    @Test
+    public void remove_created_location_by_id() {
+        final long id = testLocation.getId();
+        when(crudRepository.findById(id)).thenReturn(Optional.of(locationEntity));
 
-        // removing the same location twice should fail
-        assertThatThrownBy(() -> repository.removeLocation(location.getId()))
-                .isInstanceOf(IllegalArgumentException.class);
+        Location removed = repository.removeLocation(id);
+        assertThat(removed).isEqualTo(testLocation);
+        verify(crudRepository).deleteById(id);
+    }
+
+    @Test
+    public void removing_nonexistent_location_should_fail() {
+        when(crudRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         // removing nonexistent location should fail and its ID should appear in the exception message
         int uniqueNonexistentId = 7173;
@@ -83,27 +90,14 @@ public class LocationRepositoryImplTest {
     }
 
     @Test
-    public void get_and_remove_all_locations() {
-        int locationCount = 8;
-        for (int i = 0; i < locationCount; i++) {
-            repository.createLocation(LatLng.valueOf(1.0, i / 100.0));
-        }
-
-        assertThat(crudRepository.count()).isEqualTo(locationCount);
-
-        // get a sample location entity from the repository
-        assertThat(crudRepository.existsById((long) locationCount)).isTrue();
-        LocationEntity testEntity = crudRepository
-                .findById((long) locationCount)
-                .orElseThrow(IllegalStateException::new);
-        Location testLocation = new Location(testEntity.getId(),
-                new LatLng(testEntity.getLatitude(), testEntity.getLongitude()));
-
-        assertThat(repository.locations())
-                .hasSize(locationCount)
-                .contains(testLocation);
-
+    public void remove_all_locations() {
         repository.removeAll();
-        assertThat(crudRepository.count()).isZero();
+        verify(crudRepository).deleteAll();
+    }
+
+    @Test
+    public void get_all_locations() {
+        when(crudRepository.findAll()).thenReturn(Collections.singletonList(locationEntity));
+        assertThat(repository.locations()).containsExactly(testLocation);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/integration_tests/DistanceRepositoryIntegrationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/integration_tests/DistanceRepositoryIntegrationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.persistence.integration_tests;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.optaweb.vehiclerouting.domain.LatLng;
+import org.optaweb.vehiclerouting.domain.Location;
+import org.optaweb.vehiclerouting.plugin.persistence.DistanceCrudRepository;
+import org.optaweb.vehiclerouting.plugin.persistence.DistanceEntity;
+import org.optaweb.vehiclerouting.plugin.persistence.DistanceKey;
+import org.optaweb.vehiclerouting.plugin.persistence.DistanceRepositoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@RunWith(SpringRunner.class)
+public class DistanceRepositoryIntegrationTest {
+
+    @Autowired
+    private DistanceCrudRepository crudRepository;
+    private DistanceRepositoryImpl repository;
+
+    @Before
+    public void setUp() {
+        repository = new DistanceRepositoryImpl(crudRepository);
+    }
+
+    @Test
+    public void crudRepository() {
+        DistanceKey key = new DistanceKey(1, 2);
+        DistanceEntity entity = new DistanceEntity(key, 73.0107);
+
+        DistanceEntity savedEntity = crudRepository.save(entity);
+        assertThat(savedEntity).isEqualTo(entity);
+
+        assertThat(crudRepository.count()).isOne();
+        assertThat(crudRepository.findById(key)).get().isEqualTo(entity);
+
+        crudRepository.deleteById(key);
+        assertThat(crudRepository.count()).isZero();
+    }
+
+    @Test
+    public void should_return_saved_distance() {
+        Location location1 = new Location(1, LatLng.valueOf(7, -4.0));
+        Location location2 = new Location(2, LatLng.valueOf(5, 9.0));
+
+        double distance = 95676.6417;
+        repository.saveDistance(location1, location2, distance);
+        assertThat(repository.getDistance(location1, location2)).isEqualTo(distance);
+    }
+
+    @Test
+    public void should_return_negative_number_when_distance_not_found() {
+        Location location1 = new Location(1, LatLng.valueOf(7, -4.0));
+        Location location2 = new Location(2, LatLng.valueOf(5, 9.0));
+
+        assertThat(repository.getDistance(location1, location2)).isNegative();
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/integration_tests/LocationRepositoryIntegrationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/integration_tests/LocationRepositoryIntegrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.persistence.integration_tests;
+
+import java.math.BigDecimal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.optaweb.vehiclerouting.domain.LatLng;
+import org.optaweb.vehiclerouting.domain.Location;
+import org.optaweb.vehiclerouting.plugin.persistence.LocationCrudRepository;
+import org.optaweb.vehiclerouting.plugin.persistence.LocationEntity;
+import org.optaweb.vehiclerouting.plugin.persistence.LocationRepositoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@RunWith(SpringRunner.class)
+public class LocationRepositoryIntegrationTest {
+
+    @Autowired
+    private LocationCrudRepository crudRepository;
+    private LocationRepositoryImpl repository;
+
+    @Before
+    public void setUp() {
+        repository = new LocationRepositoryImpl(crudRepository);
+    }
+
+    @Test
+    public void db_schema() {
+        // https://wiki.openstreetmap.org/wiki/Node#Structure
+        final BigDecimal maxLatitude = new BigDecimal("90.0000000");
+        final BigDecimal maxLongitude = new BigDecimal("214.7483647");
+        final BigDecimal minLatitude = maxLatitude.negate();
+        final BigDecimal minLongitude = maxLongitude.negate();
+
+        LocationEntity minLocation = new LocationEntity(minLatitude, minLongitude);
+        LocationEntity maxLocation = new LocationEntity(maxLatitude, maxLongitude);
+        crudRepository.save(minLocation);
+        crudRepository.save(maxLocation);
+
+        assertThat(crudRepository.findById(minLocation.getId())).get().isEqualTo(minLocation);
+        assertThat(crudRepository.findById(maxLocation.getId())).get().isEqualTo(maxLocation);
+    }
+
+    @Test
+    public void remove_created_location() {
+        LatLng latLng = LatLng.valueOf(0.00213, 32.777);
+        assertThat(crudRepository.count()).isZero();
+        Location location = repository.createLocation(latLng);
+        assertThat(location.getLatLng()).isEqualTo(latLng);
+        assertThat(crudRepository.count()).isOne();
+
+        Location removed = repository.removeLocation(location.getId());
+        assertThat(removed).isEqualTo(location);
+
+        // removing the same location twice should fail
+        assertThatThrownBy(() -> repository.removeLocation(location.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // removing nonexistent location should fail and its ID should appear in the exception message
+        int uniqueNonexistentId = 7173;
+        assertThatThrownBy(() -> repository.removeLocation(uniqueNonexistentId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(String.valueOf(uniqueNonexistentId));
+    }
+
+    @Test
+    public void get_and_remove_all_locations() {
+        int locationCount = 8;
+        for (int i = 0; i < locationCount; i++) {
+            repository.createLocation(LatLng.valueOf(1.0, i / 100.0));
+        }
+
+        assertThat(crudRepository.count()).isEqualTo(locationCount);
+
+        // get a sample location entity from the repository
+        assertThat(crudRepository.existsById((long) locationCount)).isTrue();
+        LocationEntity testEntity = crudRepository
+                .findById((long) locationCount)
+                .orElseThrow(IllegalStateException::new);
+        Location testLocation = new Location(testEntity.getId(),
+                new LatLng(testEntity.getLatitude(), testEntity.getLongitude()));
+
+        assertThat(repository.locations())
+                .hasSize(locationCount)
+                .contains(testLocation);
+
+        repository.removeAll();
+        assertThat(crudRepository.count()).isZero();
+    }
+}


### PR DESCRIPTION
Line Coverage: 74% (386/525)
Mutation Coverage: 72% (452/627)
Execution time (Pitest total): 43 s

This is an improvement despite excluding `@DataJpaTest`s. Explanation:
- The slow (integration) DataJpaTests were replaced by unit tests that mock Spring CrudRepository.
- A few new tests were added.
- Number of mutations was slightly reduced by avoiding calls to `org.slf4j`.