### PR TITLE
Improve backend build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ jobs:
   include:
     - language: node_js
       node_js:
-      - 8
+        - 8
       # keep the npm cache around to speed up installs (see https://docs.npmjs.com/cli/ci)
       cache:
         directories:
@@ -27,5 +27,11 @@ jobs:
           - "$HOME/.sonar/cache"
       before_install:
         - "cd optaweb-vehicle-routing-backend"
+      # Change Travis install phase to only resolve dependencies needed to run the build.
+      # Otherwise it would run `mvn install`, which results in doing some Maven phases twice (validate, compile, jar, ...).
+      # https://docs.travis-ci.com/user/languages/java/#projects-using-maven
+      #
+      # We also want to avoid Maven's install phase to prevent from writing to ~/.m2/repository, which is cached.
+      install: ./mvnw dependency:go-offline -Pjacoco,sonar --show-version
       # do not install to avoid dirtying the cache
-      script: ./mvnw verify -Pjacoco,sonar
+      script: ./mvnw verify -Pjacoco,sonar --show-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
       cache:
         directories:
           - "$HOME/.m2/repository"
+          - "$HOME/.m2/wrapper"
           - "$HOME/.sonar/cache"
       before_install:
         - "cd optaweb-vehicle-routing-backend"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+git:
+  depth: false
 jobs:
   include:
     - language: node_js


### PR DESCRIPTION
- Keep the cache clean (don't pollute it with build artifacts). This is done by avoiding `mvn install`.
- Cache Maven Wrapper. Unless a dependency upgrade occurs, we now have 0 Maven downloads during the build.
- Disable Git shallow clone. This might unlock some SCM related features on SonarCloud. At least it removes a warning visible in the UI.