### PR TITLE
Rename WorkInProgress to UnderConstruction

### DIFF
--- a/optaweb-vehicle-routing-frontend/src/ui/components/UnderConstruction.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/UnderConstruction.test.tsx
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-import { Bullseye, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { InProgressIcon } from '@patternfly/react-icons';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import * as React from 'react';
+import { UnderConstruction } from './UnderConstruction';
 
-export function WorkInProgress() {
-  return (
-    <Bullseye>
-      <TextContent>
-        <Text component={TextVariants.h1}>
-          <InProgressIcon /> Work in progress
-        </Text>
-      </TextContent>
-    </Bullseye>
-  );
-}
+describe('Under Construction', () => {
+  it('should render correctly', () => {
+    const underConstruction = shallow(<UnderConstruction />);
+    expect(toJson(underConstruction)).toMatchSnapshot();
+  });
+});

--- a/optaweb-vehicle-routing-frontend/src/ui/components/UnderConstruction.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/UnderConstruction.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Bullseye, GutterSize, Stack, StackItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { HammerIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+
+export function UnderConstruction() {
+  return (
+    <Bullseye>
+      <div>
+        <Stack gutter={GutterSize.md}>
+          <StackItem isFilled={false}>
+            <Bullseye>
+              <HammerIcon height={48} width={48} />
+            </Bullseye>
+          </StackItem>
+          <StackItem isFilled={false}>
+            <TextContent>
+              <Text component={TextVariants.h1}>
+                Under construction
+              </Text>
+            </TextContent>
+          </StackItem>
+        </Stack>
+      </div>
+    </Bullseye>
+  );
+}

--- a/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/UnderConstruction.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/UnderConstruction.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Under Construction should render correctly 1`] = `
+<Bullseye
+  className=""
+  component="div"
+>
+  <div>
+    <Stack
+      className=""
+      component="div"
+      gutter="md"
+    >
+      <StackItem
+        className=""
+        isFilled={false}
+      >
+        <Bullseye
+          className=""
+          component="div"
+        >
+          <HammerIcon
+            color="currentColor"
+            height={48}
+            size="sm"
+            title={null}
+            width={48}
+          />
+        </Bullseye>
+      </StackItem>
+      <StackItem
+        className=""
+        isFilled={false}
+      >
+        <TextContent>
+          <Text
+            component="h1"
+          >
+            Under construction
+          </Text>
+        </TextContent>
+      </StackItem>
+    </Stack>
+  </div>
+</Bullseye>
+`;

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import * as React from 'react';
-import { UnderConstruction } from 'ui/components/UnderConstruction';
+import Vehicles from './Vehicles';
 
-const Vehicles = () => {
-  return <UnderConstruction />;
-};
-
-export default Vehicles;
+describe('Vehicles page', () => {
+  it('should render correctly', () => {
+    const vehicles = shallow(<Vehicles />);
+    expect(toJson(vehicles)).toMatchSnapshot();
+  });
+});

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Vehicles page should render correctly 1`] = `<UnderConstruction />`;


### PR DESCRIPTION
Work in progress could have been interpreted as if there was a background task going on (e.g. loading data from server).

![localhost_3000_vehicles(PF minimal lg 16_9)](https://user-images.githubusercontent.com/673386/58700874-a7d15d00-83a1-11e9-8ca3-721fd8264c20.png)
