### PR TITLE
Prepare the repository to be added to KIE group's repository-list.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ cache:
 install: mvn dependency:go-offline -Pcode-coverage,sonar --show-version
 # do not install to avoid dirtying the cache
 script:
-  - mvn verify -Pcode-coverage,sonar --show-version
+  - mvn verify -Pcode-coverage --show-version
+  - mvn generate-resources -Psonarcloud-analysis
   # check that git working tree is clean after running npm install via a frontend-maven-plugin
   # the git command returns 1 and fails the build if there are any uncommitted changes
   - git diff HEAD --exit-code

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ cache:
 # https://docs.travis-ci.com/user/languages/java/#projects-using-maven
 #
 # We also want to avoid Maven's install phase to prevent from writing to ~/.m2/repository, which is cached.
-install: mvn dependency:go-offline -Pjacoco,sonar --show-version
+install: mvn dependency:go-offline -Pcode-coverage,sonar --show-version
 # do not install to avoid dirtying the cache
 script:
-  - mvn verify -Pjacoco,sonar --show-version
+  - mvn verify -Pcode-coverage,sonar --show-version
   # check that git working tree is clean after running npm install via a frontend-maven-plugin
   # the git command returns 1 and fails the build if there are any uncommitted changes
   - git diff HEAD --exit-code

--- a/README.adoc
+++ b/README.adoc
@@ -1,20 +1,18 @@
+:projectKey: org.optaweb.vehiclerouting:optaweb-vehicle-routing
+:sonarBadge: image:https://sonarcloud.io/api/project_badges/measure?project={projectKey}
+:sonarLink: link="https://sonarcloud.io/dashboard?id={projectKey}"
+
 = OptaWeb Vehicle Routing
 
 image:https://travis-ci.com/kiegroup/optaweb-vehicle-routing.svg?branch=master[
 "Build Status", link="https://travis-ci.com/kiegroup/optaweb-vehicle-routing"]
 
-image:https://sonarcloud.io/api/project_badges/measure?project=org.optaweb:vehicle-routing&metric=alert_status[
-"Quality Gate Status", link="https://sonarcloud.io/dashboard?id=org.optaweb:vehicle-routing"]
-image:https://sonarcloud.io/api/project_badges/measure?project=org.optaweb:vehicle-routing&metric=reliability_rating[
-"Reliability Rating", link="https://sonarcloud.io/dashboard?id=org.optaweb:vehicle-routing"]
-image:https://sonarcloud.io/api/project_badges/measure?project=org.optaweb:vehicle-routing&metric=security_rating[
-"Security Rating", link="https://sonarcloud.io/dashboard?id=org.optaweb:vehicle-routing"]
-image:https://sonarcloud.io/api/project_badges/measure?project=org.optaweb:vehicle-routing&metric=sqale_rating[
-"Maintainability Rating", link="https://sonarcloud.io/dashboard?id=org.optaweb:vehicle-routing"]
-image:https://sonarcloud.io/api/project_badges/measure?project=org.optaweb:vehicle-routing&metric=ncloc[
-"Lines of Code", link="https://sonarcloud.io/dashboard?id=org.optaweb:vehicle-routing"]
-image:https://sonarcloud.io/api/project_badges/measure?project=org.optaweb:vehicle-routing&metric=coverage[
-"Coverage", link="https://sonarcloud.io/dashboard?id=org.optaweb:vehicle-routing"]
+{sonarBadge}&metric=alert_status["Quality Gate Status", {sonarLink}]
+{sonarBadge}&metric=reliability_rating["Reliability Rating", {sonarLink}]
+{sonarBadge}&metric=security_rating["Security Rating", {sonarLink}]
+{sonarBadge}&metric=sqale_rating["Maintainability Rating", {sonarLink}]
+{sonarBadge}&metric=ncloc["Lines of Code", {sonarLink}]
+{sonarBadge}&metric=coverage["Coverage", {sonarLink}]
 
 Web application for solving the https://www.optaplanner.org/learn/useCases/vehicleRoutingProblem.html[Vehicle Routing Problem]
 using https://www.optaplanner.org/[OptaPlanner].

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -52,7 +52,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-    <version.org.jacoco>0.8.3</version.org.jacoco>
   </properties>
 
   <dependencies>
@@ -200,53 +199,6 @@
               <param>*IntegrationTest</param>
             </excludedTestClasses>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>${version.org.jacoco}</version>
-          <executions>
-            <execution>
-              <id>default-instrument</id>
-              <goals>
-                <goal>instrument</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>default-restore-instrumented-classes</id>
-              <goals>
-                <goal>restore-instrumented-classes</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>default-report</id>
-              <phase>prepare-package</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>default-check</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <configuration>
-                <haltOnFailure>true</haltOnFailure>
-                <rules>
-                  <rule>
-                    <element>BUNDLE</element>
-                    <limits>
-                      <limit>
-                        <counter>LINE</counter>
-                        <value>COVEREDRATIO</value>
-                        <minimum>0.5</minimum>
-                      </limit>
-                    </limits>
-                  </rule>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -166,7 +166,9 @@
               <version>0.8</version>
             </dependency>
           </dependencies>
-          <configuration>
+          <!-- kie-parent contains Pitest configuration that doesn't work well for this project and it's not possible to change it
+               without a complete override (combine.self="override), for example excludedClasses, timeoutConstant. -->
+          <configuration combine.self="override">
             <reportsDirectory>local/pit-reports</reportsDirectory>
             <timestampedReports>true</timestampedReports>
             <!--

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.optaweb.vehiclerouting</groupId>
   <artifactId>optaweb-vehicle-routing-backend</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>7.25.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>OptaWeb Vehicle Routing Backend</name>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -19,16 +19,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.optaweb.vehiclerouting</groupId>
+    <artifactId>optaweb-vehicle-routing</artifactId>
+    <version>7.25.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>optaweb-vehicle-routing-backend</artifactId>
   <packaging>jar</packaging>
 
   <name>OptaWeb Vehicle Routing Backend</name>
-
-  <parent>
-    <groupId>org.optaweb.vehiclerouting</groupId>
-    <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
-    <version>7.25.0-SNAPSHOT</version>
-  </parent>
 
   <properties>
     <checkstyle.header.template><![CDATA[

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -83,6 +83,12 @@
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
         </exclusion>
+        <!-- Banned by KIE's Enforcer rules. No need to add a slf4j bridge (org.apache.logging.log4j:log4j-api)
+             as it's already included by one of the Spring Boot starters. -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -382,12 +382,4 @@
       </build>
     </profile>
   </profiles>
-
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-    </repository>
-  </repositories>
 </project>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -109,27 +109,22 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-examples</artifactId>
-      <version>7.17.0.Final</version>
     </dependency>
     <dependency>
       <groupId>com.graphhopper</groupId>
       <artifactId>graphhopper-reader-osm</artifactId>
-      <version>0.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.neovisionaries</groupId>
       <artifactId>nv-i18n</artifactId>
-      <version>1.24</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.1</version>
     </dependency>
     <!-- Enable Spring Boot Automatic Restart, see Development Guide in Readme to learn how to use it. -->
     <dependency>
@@ -350,39 +345,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jacoco</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.agent</artifactId>
-          <version>${version.org.jacoco}</version>
-          <classifier>runtime</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <systemPropertyVariables>
-                  <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
-                </systemPropertyVariables>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -19,18 +19,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.optaweb.vehiclerouting</groupId>
   <artifactId>optaweb-vehicle-routing-backend</artifactId>
-  <version>7.25.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>OptaWeb Vehicle Routing Backend</name>
 
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.5.RELEASE</version>
-    <relativePath/> <!-- lookup parent from repository -->
+    <groupId>org.optaweb.vehiclerouting</groupId>
+    <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
+    <version>7.25.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Coordinates.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Coordinates.java
@@ -36,10 +36,18 @@ public class Coordinates {
         return new Coordinates(BigDecimal.valueOf(latitude), BigDecimal.valueOf(longitude));
     }
 
+    /**
+     * Latitude.
+     * @return latitude (never {@code null})
+     */
     public BigDecimal latitude() {
         return latitude;
     }
 
+    /**
+     * Longitude.
+     * @return longitude (never {@code null})
+     */
     public BigDecimal longitude() {
         return longitude;
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocation.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocation.java
@@ -19,6 +19,7 @@ package org.optaweb.vehiclerouting.plugin.websocket;
 import java.math.BigDecimal;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.optaweb.vehiclerouting.domain.Location;
 
@@ -45,11 +46,17 @@ class PortableLocation {
         );
     }
 
-    PortableLocation(long id, BigDecimal latitude, BigDecimal longitude, String description) {
+    @JsonCreator
+    PortableLocation(
+            @JsonProperty(value = "id") long id,
+            @JsonProperty(value = "lat") BigDecimal latitude,
+            @JsonProperty(value = "lng") BigDecimal longitude,
+            @JsonProperty(value = "description") String description
+    ) {
         this.id = id;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.description = description;
+        this.latitude = Objects.requireNonNull(latitude);
+        this.longitude = Objects.requireNonNull(longitude);
+        this.description = Objects.requireNonNull(description);
     }
 
     public long getId() {
@@ -79,8 +86,8 @@ class PortableLocation {
         PortableLocation that = (PortableLocation) o;
         return id == that.id &&
                 Objects.equals(description, that.description) &&
-                Objects.equals(latitude, that.latitude) &&
-                Objects.equals(longitude, that.longitude);
+                latitude.compareTo(that.latitude) == 0 &&
+                longitude.compareTo(that.longitude) == 0;
     }
 
     @Override

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocationTest.java
@@ -16,15 +16,38 @@
 
 package org.optaweb.vehiclerouting.plugin.websocket;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
+import org.springframework.boot.test.json.JacksonTester;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PortableLocationTest {
+
+    private JacksonTester<PortableLocation> json;
+    private final PortableLocation portableLocation = new PortableLocation(987, BigDecimal.ONE, BigDecimal.TEN, "Some Location");
+
+    @BeforeEach
+    public void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JacksonTester.initFields(this, objectMapper);
+    }
+
+    @Test
+    public void marshall_to_json() throws IOException {
+        assertThat(json.write(portableLocation)).isEqualToJson("portable-location.json");
+    }
+
+    @Test
+    public void unmarshall_from_json() throws IOException {
+        assertThat(json.read("portable-location.json")).isEqualTo(portableLocation);
+    }
 
     @Test
     public void fromLocation() {

--- a/optaweb-vehicle-routing-backend/src/test/resources/org/optaweb/vehiclerouting/plugin/websocket/portable-location.json
+++ b/optaweb-vehicle-routing-backend/src/test/resources/org/optaweb/vehiclerouting/plugin/websocket/portable-location.json
@@ -1,0 +1,6 @@
+{
+  "id": 987,
+  "lat": 1.0,
+  "lng": 10.0,
+  "description": "Some Location"
+}

--- a/optaweb-vehicle-routing-frontend/README.adoc
+++ b/optaweb-vehicle-routing-frontend/README.adoc
@@ -1,10 +1,14 @@
+:david-project: https://david-dm.org/kiegroup/optaweb-vehicle-routing
+:david-path: path=optaweb-vehicle-routing-frontend
+:david-deps: {david-project}/status.svg?{david-path}
+:david-devDeps: {david-project}/dev-status.svg?{david-path}
+:david-link: {david-project}?{david-path}
+
 [[optaweb-vehicle-routing-frontend]]
 = OptaWeb Vehicle Routing Frontend
 
-image:https://david-dm.org/kiegroup/optaweb-vehicle-routing/status.svg?path=optaweb-vehicle-routing-frontend[
-"dependencies Status", link="https://david-dm.org/kiegroup/optaweb-vehicle-routing?path=optaweb-vehicle-routing-frontend"]
-image:https://david-dm.org/kiegroup/optaweb-vehicle-routing/dev-status.svg?path=optaweb-vehicle-routing-frontend[
-"devDependencies Status", link="https://david-dm.org/kiegroup/optaweb-vehicle-routing?path=optaweb-vehicle-routing-frontend&type=dev"]
+image:{david-deps}["dependencies Status", link="{david-link}"]
+image:{david-devDeps}["devDependencies Status", link="{david-link}&type=dev"]
 
 [[available-scripts]]
 == Available Scripts

--- a/optaweb-vehicle-routing-frontend/package-lock.json
+++ b/optaweb-vehicle-routing-frontend/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "optaweb-vehicle-routing-frontend",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -2524,7 +2525,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -2631,7 +2632,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
@@ -2751,7 +2752,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -3203,22 +3204,22 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -3931,7 +3932,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3965,7 +3966,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -4014,7 +4015,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -4136,7 +4137,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
@@ -4194,7 +4195,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -4879,7 +4880,7 @@
     },
     "clone-deep": {
       "version": "0.2.4",
-      "resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "requires": {
         "for-own": "^0.1.3",
@@ -5087,7 +5088,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5101,7 +5102,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5264,7 +5265,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -5276,7 +5277,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -5345,7 +5346,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-declaration-sorter": {
@@ -5750,7 +5751,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -5762,7 +5763,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
@@ -5827,7 +5828,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -5900,7 +5901,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
@@ -5960,7 +5961,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer2": {
@@ -5978,7 +5979,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5992,7 +5993,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -6018,7 +6019,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6032,7 +6033,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -6594,7 +6595,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -6619,7 +6620,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -7236,7 +7237,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7250,7 +7251,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -7577,7 +7578,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7591,7 +7592,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -8029,7 +8030,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8043,7 +8044,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -8770,7 +8771,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
@@ -10576,7 +10577,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-parse-better-errors": {
@@ -10619,7 +10620,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -10661,7 +10662,7 @@
     },
     "kind-of": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
       "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "kleur": {
@@ -11001,7 +11002,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -11037,7 +11038,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11051,7 +11052,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11109,7 +11110,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11123,7 +11124,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11257,7 +11258,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
@@ -11284,7 +11285,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11298,7 +11299,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11357,7 +11358,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -11570,7 +11571,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11584,7 +11585,7 @@
           "dependencies": {
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -11951,7 +11952,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -11966,7 +11967,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
@@ -12045,7 +12046,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -12059,7 +12060,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -12149,7 +12150,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -14358,7 +14359,7 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -14384,7 +14385,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -14398,7 +14399,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -14557,7 +14558,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -14876,7 +14877,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -14905,7 +14906,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -15141,7 +15142,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -15166,7 +15167,7 @@
         },
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -15691,7 +15692,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -15705,7 +15706,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -15741,7 +15742,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -15755,7 +15756,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -15834,7 +15835,7 @@
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-object": {
@@ -15849,7 +15850,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -15871,7 +15872,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -16119,12 +16120,12 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
       "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "requires": {
         "readable-stream": "~1.0.17",
@@ -17277,7 +17278,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/optaweb-vehicle-routing-frontend/package.json
+++ b/optaweb-vehicle-routing-frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "optaweb-vehicle-routing-frontend",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -48,6 +48,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
+            <phase>compile</phase>
             <configuration>
               <arguments>install</arguments>
             </configuration>
@@ -64,6 +65,7 @@
           </execution>
           <execution>
             <id>npm run build</id>
+            <phase>package</phase>
             <goals>
               <goal>npm</goal>
             </goals>

--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -19,9 +19,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.optaweb.vehiclerouting</groupId>
+  <parent>
+    <groupId>org.optaweb.vehiclerouting</groupId>
+    <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
+    <version>7.25.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>optaweb-vehicle-routing-frontend</artifactId>
-  <version>7.25.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>OptaWeb Vehicle Routing Frontend</name>

--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.optaweb.vehiclerouting</groupId>
   <artifactId>optaweb-vehicle-routing-frontend</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>7.25.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>OptaWeb Vehicle Routing Frontend</name>

--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -21,7 +21,7 @@
 
   <parent>
     <groupId>org.optaweb.vehiclerouting</groupId>
-    <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
+    <artifactId>optaweb-vehicle-routing</artifactId>
     <version>7.25.0-SNAPSHOT</version>
   </parent>
 

--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -30,6 +30,12 @@
 
   <name>OptaWeb Vehicle Routing Frontend</name>
 
+  <properties>
+    <sonar.sources>src</sonar.sources>
+    <sonar.test.inclusions>optaweb-vehicle-routing-frontend/**/*test.ts,optaweb-vehicle-routing-frontend/**/*test.tsx</sonar.test.inclusions>
+    <sonar.typescript.lcov.reportPaths>coverage/lcov.info</sonar.typescript.lcov.reportPaths>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -81,16 +87,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>sonar</id>
-      <properties>
-        <sonar.sources>src</sonar.sources>
-        <sonar.test.inclusions>optaweb-vehicle-routing-frontend/**/*test.ts,optaweb-vehicle-routing-frontend/**/*test.tsx</sonar.test.inclusions>
-        <sonar.typescript.lcov.reportPaths>coverage/lcov.info</sonar.typescript.lcov.reportPaths>
-      </properties>
-    </profile>
-  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,26 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.9.9.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>2.9.9</version>
+      </dependency>
+      <dependency>
+        <groupId>com.graphhopper</groupId>
+        <artifactId>graphhopper-reader-osm</artifactId>
+        <version>0.11.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.neovisionaries</groupId>
+        <artifactId>nv-i18n</artifactId>
+        <version>1.24</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,33 +91,6 @@
 
   <profiles>
     <profile>
-      <id>sonar</id>
-      <properties>
-        <sonar.projectKey>org.optaweb:vehicle-routing</sonar.projectKey>
-        <sonar.organization>kiegroup</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io/</sonar.host.url>
-        <!--suppress UnresolvedMavenProperty -->
-        <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.sonarsource.scanner.maven</groupId>
-            <artifactId>sonar-maven-plugin</artifactId>
-            <version>3.6.0.1398</version>
-            <executions>
-              <execution>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sonar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <!-- Skip Sonar plugin execution if SONARCLOUD_TOKEN is not set. -->
       <id>skipSonar</id>
       <activation>
@@ -130,7 +103,7 @@
       </properties>
     </profile>
     <profile>
-      <id>pullRequestAnalysis</id>
+      <id>pullRequestAnalysis-Travis</id>
       <!-- Only set sonar.pullrequest properties when the Travis build is triggered by a PR.
            When the build is triggered by push to a branch or by cron, the consumed env.TRAVIS properties are empty,
            resulting in invalid sonar.pullrequest properties and the Sonar plugin would fail. -->
@@ -152,7 +125,7 @@
       </properties>
     </profile>
     <profile>
-      <id>branchAnalysis</id>
+      <id>branchAnalysis-Travis</id>
       <activation>
         <property>
           <name>env.TRAVIS_EVENT_TYPE</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-parent</artifactId>
+    <version>7.25.0-SNAPSHOT</version>
+  </parent>
+
   <groupId>org.optaweb.vehiclerouting</groupId>
   <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
-  <version>7.25.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>OptaWeb Vehicle Routing Aggregate</name>
@@ -137,4 +142,22 @@
       </properties>
     </profile>
   </profiles>
+
+  <repositories>
+    <!-- Bootstrap repository to locate the parent POM when it has not been built locally. -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.optaweb.vehiclerouting</groupId>
   <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>7.25.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>OptaWeb Vehicle Routing Aggregate</name>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   </modules>
 
   <properties>
+    <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.org.assertj>3.11.1</version.org.assertj>
     <version.org.mockito>2.23.4</version.org.mockito>
     <version.org.springframework>5.1.7.RELEASE</version.org.springframework>

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
   </parent>
 
   <groupId>org.optaweb.vehiclerouting</groupId>
-  <artifactId>optaweb-vehicle-routing-aggregate</artifactId>
+  <artifactId>optaweb-vehicle-routing</artifactId>
   <packaging>pom</packaging>
 
-  <name>OptaWeb Vehicle Routing Aggregate</name>
+  <name>OptaWeb Vehicle Routing</name>
 
   <modules>
     <module>optaweb-vehicle-routing-backend</module>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   </modules>
 
   <properties>
+    <version.org.springframework>5.1.7.RELEASE</version.org.springframework>
     <version.org.springframework.boot>2.1.5.RELEASE</version.org.springframework.boot>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,34 @@
     <module>optaweb-vehicle-routing-frontend</module>
   </modules>
 
+  <properties>
+    <version.org.springframework.boot>2.1.5.RELEASE</version.org.springframework.boot>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${version.org.springframework.boot}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${version.org.springframework.boot}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <profiles>
     <profile>
       <id>sonar</id>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   </modules>
 
   <properties>
+    <jacoco.line.coveredratio.minimum>0.8</jacoco.line.coveredratio.minimum>
     <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.org.assertj>3.11.1</version.org.assertj>
     <version.org.mockito>2.23.4</version.org.mockito>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
   </modules>
 
   <properties>
-    <jacoco.line.coveredratio.minimum>0.8</jacoco.line.coveredratio.minimum>
     <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.org.assertj>3.11.1</version.org.assertj>
     <version.org.mockito>2.23.4</version.org.mockito>
@@ -84,6 +83,21 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${version.org.springframework.boot}</version>
+        </plugin>
+        <!-- Disable Jacoco check inherited from kie-parent. Remove this when it's removed from kie-parent (but some projects
+             still use the check fail build). -->
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>none</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
   </modules>
 
   <properties>
+    <version.org.assertj>3.11.1</version.org.assertj>
+    <version.org.mockito>2.23.4</version.org.mockito>
     <version.org.springframework>5.1.7.RELEASE</version.org.springframework>
     <version.org.springframework.boot>2.1.5.RELEASE</version.org.springframework.boot>
   </properties>


### PR DESCRIPTION
## Summary of changes
- Root POM is now parent of backend and frontend modules. `kie-parent` is now parent of root POM.
- `spring-boot-starter-parent` is no longer parent of backend but we import `spring-boot-dependencies` for dependency management.
- Overriding a few versions from `kie-parent` in order to build successfully under its dependency management.
- Bound npm scripts to Maven phases that make most sense so if you, for example, run `mvn generate-resources` Maven doesn't run tests and the production build.
- Removed Jacoco and Sonar plugin configurations that are already defined in `kie-parent`. Keeping pull request and branch analysis profiles that activate smartly on Travis.
- Changed SonarCloud project's key, renamed root pom to `org.optaweb.vehiclerouting:optaweb-vehicle-routing`.

## TODO
- [x] Figure out why Pitest takes 5 minutes to execute after the change and fix it (should take around 45s).

## TODO (non-blocking)
- [ ] Review effective pom, override things like description, scm, issues, inception year, etc.
- [ ] Review and unify `maven-compiler-plugin` configuration.
- [ ] Review and unify `pitest-maven` configuration.
- [ ] Avoid version overrides -> upgrade them in kie-parent. Probably not now but in the future. Add TODOs in the code?
- [ ] Remove junit and mockito from kie-parent's dependencies! OK, it still doesn't break anything but now I'm inheriting these in *my* project and I don't like it :smile: (and there's no way to exclude them). And that's a damn good reason to clean it up :smile:.
- [x] Unify profile names for Jacoco and Pitest, remove property activation where it's redundant.