### PR TITLE
Exclude a few javax APIs that are already dragged in by Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,21 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-examples</artifactId>
+        <version>${version.org.optaplanner}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>2.9.9.1</version>


### PR DESCRIPTION
Necessary to comply with Enforcer's `banDuplicateClasses` rule.

This is a temporary solution. Once we drop dependency on `optaplanner-examples`, which we only have to get VRP domain for free, the colliding artifacts will disappear.