### PR TITLE
PLANNER-1418: Vehicles groundwork

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Location.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Location.java
@@ -35,6 +35,10 @@ public class Location extends LocationData {
         this.id = id;
     }
 
+    /**
+     * Location's ID.
+     * @return unique ID
+     */
     public long id() {
         return id;
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/LocationData.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/LocationData.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 /**
  * Location properties. It's not an entity yet (it doesn't have an identity, it's a value object).
- * Might be the data about a location sent from a client or data stored in a file,
+ * It might be the data about a location sent from a client or data stored in a file,
  * ready to be loaded but not yet tied to a specific location entity.
  */
 public class LocationData {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Route.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Route.java
@@ -27,15 +27,18 @@ import java.util.stream.Collectors;
  */
 public class Route {
 
+    private final Vehicle vehicle;
     private final Location depot;
     private final List<Location> visits;
 
     /**
      * Create a vehicle route.
+     * @param vehicle the vehicle assigned to this route (not null)
      * @param depot vehicle's depot (not null)
      * @param visits list of visits (not null)
      */
-    public Route(Location depot, List<Location> visits) {
+    public Route(Vehicle vehicle, Location depot, List<Location> visits) {
+        this.vehicle = Objects.requireNonNull(vehicle);
         this.depot = Objects.requireNonNull(depot);
         this.visits = new ArrayList<>(Objects.requireNonNull(visits));
         // TODO Probably remove this check when we have more types: new Route(Depot depot, List<Visit> visits).
@@ -49,6 +52,14 @@ public class Route {
             long duplicates = visits.size() - uniqueVisits;
             throw new IllegalArgumentException("Some customer have been visited multiple times (" + duplicates + ")");
         }
+    }
+
+    /**
+     * The vehicle assigned to this route.
+     * @return route's vehicle (never null)
+     */
+    public Vehicle vehicle() {
+        return vehicle;
     }
 
     /**
@@ -70,7 +81,8 @@ public class Route {
     @Override
     public String toString() {
         return "Route{" +
-                "depot=" + depot.id() +
+                "vehicle=" + vehicle +
+                ", depot=" + depot.id() +
                 ", visits=" + visits.stream().map(Location::id).collect(Collectors.toList()) +
                 '}';
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Route.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Route.java
@@ -23,7 +23,12 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Vehicle's itinerary (sequence of visits) and depot.
+ * Vehicle's itinerary (sequence of visits) and its depot. This entity cannot exist without the vehicle and the depot
+ * but it's allowed to have no visits when the vehicle hasn't been assigned any (it's idle).
+ * <p>
+ * This entity describes part of a solution of the vehicle routing problem (assignment of a subset of visits to one of
+ * the vehicles). It doesn't carry the data about physical tracks between adjacent visits. Geographical data is held by
+ * {@link RouteWithTrack}.
  */
 public class Route {
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RouteWithTrack.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RouteWithTrack.java
@@ -22,7 +22,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Vehicle's itinerary including detailed geographical description of the route.
+ * Vehicle's {@link Route itinerary} enriched with detailed geographical description of the route.
+ * This object contains data needed to visualize vehicle's route on a map.
  */
 public class RouteWithTrack extends Route {
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RouteWithTrack.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RouteWithTrack.java
@@ -35,7 +35,7 @@ public class RouteWithTrack extends Route {
      * @param track track going through all visits (not null)
      */
     public RouteWithTrack(Route route, List<List<Coordinates>> track) {
-        super(route.depot(), route.visits());
+        super(route.vehicle(), route.depot(), route.visits());
         this.track = new ArrayList<>(Objects.requireNonNull(track));
         if (route.visits().isEmpty() && !track.isEmpty() || !route.visits().isEmpty() && track.isEmpty()) {
             throw new IllegalArgumentException("Route and track must be either both empty or both non-empty");

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RoutingPlan.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RoutingPlan.java
@@ -30,6 +30,7 @@ public class RoutingPlan {
     private static final RoutingPlan EMPTY = new RoutingPlan("", null, Collections.emptyList());
 
     private final String distance;
+    // TODO vehicles (because no depot => no routes => no vehicles, therefore we need to keep vehicles separately)
     private final Location depot;
     private final List<RouteWithTrack> routes;
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RoutingPlan.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RoutingPlan.java
@@ -30,8 +30,6 @@ import static java.util.Collections.emptyList;
  */
 public class RoutingPlan {
 
-    private static final RoutingPlan EMPTY = new RoutingPlan("", emptyList(), null, emptyList());
-
     private final String distance;
     private final List<Vehicle> vehicles;
     private final Location depot;
@@ -53,7 +51,6 @@ public class RoutingPlan {
             if (!routes.isEmpty()) {
                 throw new IllegalArgumentException("Routes must be empty when depot is null.");
             }
-            // TODO fixme non-viable mutations
         } else if (routes.size() != vehicles.size()) {
             throw new IllegalArgumentException(describeVehiclesRoutesInconsistency(
                     "There must be exactly one route per vehicle", vehicles, routes
@@ -89,7 +86,7 @@ public class RoutingPlan {
      * @return empty routing plan
      */
     public static RoutingPlan empty() {
-        return EMPTY;
+        return new RoutingPlan("", emptyList(), null, emptyList());
     }
 
     /**
@@ -122,5 +119,14 @@ public class RoutingPlan {
      */
     public Optional<Location> depot() {
         return Optional.ofNullable(depot);
+    }
+
+    /**
+     * Routing plan is empty when there is no depot, no vehicles and no routes.
+     * @return {@code true} if the plan is empty
+     */
+    public boolean isEmpty() {
+        // No need to check routes. No depot => no routes.
+        return depot == null && vehicles.isEmpty();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Vehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Vehicle.java
@@ -18,6 +18,9 @@ package org.optaweb.vehiclerouting.domain;
 
 import java.util.Objects;
 
+/**
+ * Vehicle that can be used to deliver cargo to visits.
+ */
 public class Vehicle {
 
     private final long id;
@@ -28,10 +31,18 @@ public class Vehicle {
         this.name = Objects.requireNonNull(name);
     }
 
+    /**
+     * Vehicle's ID.
+     * @return unique ID
+     */
     public long id() {
         return id;
     }
 
+    /**
+     * Vehicle's name (unique description).
+     * @return vehicle's name
+     */
     public String name() {
         return name;
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Vehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Vehicle.java
@@ -66,6 +66,9 @@ public class Vehicle {
 
     @Override
     public String toString() {
-        return name;
+        return "Vehicle{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Vehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Vehicle.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.domain;
+
+import java.util.Objects;
+
+public class Vehicle {
+
+    private final long id;
+    private final String name;
+
+    public Vehicle(long id, String name) {
+        this.id = id;
+        this.name = Objects.requireNonNull(name);
+    }
+
+    public long id() {
+        return id;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Vehicle vehicle = (Vehicle) o;
+        return id == vehicle.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
@@ -222,6 +222,7 @@ class RouteOptimizerImpl implements RouteOptimizer,
         }
         if (!isSolving()) {
             solution.getVehicleList().add(vehicle);
+            // TODO publish new route
         } else {
             solver.addProblemFactChange(new AddVehicle(vehicle));
         }
@@ -230,6 +231,7 @@ class RouteOptimizerImpl implements RouteOptimizer,
     @Override
     public void clear() {
         stopSolver();
+        // TODO keep vehicles, only remove depot and visits
         solution = SolutionUtil.initialSolution();
         publishRoute(solution);
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
@@ -27,10 +27,12 @@ import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.event.BestSolutionChangedEvent;
 import org.optaplanner.core.api.solver.event.SolverEventListener;
 import org.optaplanner.examples.vehiclerouting.domain.Depot;
+import org.optaplanner.examples.vehiclerouting.domain.Vehicle;
 import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 import org.optaplanner.examples.vehiclerouting.domain.location.Location;
 import org.optaplanner.examples.vehiclerouting.domain.location.RoadLocation;
 import org.optaweb.vehiclerouting.plugin.planner.change.AddCustomer;
+import org.optaweb.vehiclerouting.plugin.planner.change.AddVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.change.RemoveCustomer;
 import org.optaweb.vehiclerouting.plugin.planner.change.RemoveLocation;
 import org.optaweb.vehiclerouting.service.location.DistanceMatrix;
@@ -207,6 +209,21 @@ class RouteOptimizerImpl implements RouteOptimizer,
             } else {
                 solver.addProblemFactChanges(Arrays.asList(new RemoveCustomer(location), new RemoveLocation(location)));
             }
+        }
+    }
+
+    @Override
+    public void addVehicle(org.optaweb.vehiclerouting.domain.Vehicle domainVehicle) {
+        Vehicle vehicle = new Vehicle();
+        vehicle.setId(domainVehicle.id());
+        vehicle.setCapacity(SolutionUtil.DEFAULT_VEHICLE_CAPACITY);
+        if (!solution.getDepotList().isEmpty()) {
+            vehicle.setDepot(solution.getDepotList().get(0));
+        }
+        if (!isSolving()) {
+            solution.getVehicleList().add(vehicle);
+        } else {
+            solver.addProblemFactChange(new AddVehicle(vehicle));
         }
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
@@ -82,7 +82,13 @@ class RouteOptimizerImpl implements RouteOptimizer,
         );
         List<ShallowRoute> routes = SolutionUtil.routes(solution);
         logger.debug("Routes: {}", routes);
-        publisher.publishEvent(new RouteChangedEvent(this, distanceString, SolutionUtil.depot(solution), routes));
+        publisher.publishEvent(new RouteChangedEvent(
+                this,
+                distanceString,
+                SolutionUtil.vehicleIds(solution),
+                SolutionUtil.depotId(solution),
+                routes
+        ));
     }
 
     private void startSolver() {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
@@ -228,7 +228,7 @@ class RouteOptimizerImpl implements RouteOptimizer,
         }
         if (!isSolving()) {
             solution.getVehicleList().add(vehicle);
-            // TODO publish new route
+            publishRoute(solution);
         } else {
             solver.addProblemFactChange(new AddVehicle(vehicle));
         }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtil.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtil.java
@@ -61,14 +61,7 @@ public class SolutionUtil {
      * @return initial solution
      */
     static VehicleRoutingSolution initialSolution() {
-        VehicleRoutingSolution solution = emptySolution();
-        addVehicle(solution, 1, DEFAULT_VEHICLE_CAPACITY);
-        addVehicle(solution, 2, DEFAULT_VEHICLE_CAPACITY);
-        addVehicle(solution, 3, DEFAULT_VEHICLE_CAPACITY);
-        addVehicle(solution, 4, DEFAULT_VEHICLE_CAPACITY);
-        addVehicle(solution, 5, DEFAULT_VEHICLE_CAPACITY);
-        addVehicle(solution, 6, DEFAULT_VEHICLE_CAPACITY);
-        return solution;
+        return emptySolution();
     }
 
     /**

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtil.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtil.java
@@ -118,7 +118,7 @@ public class SolutionUtil {
                 }
                 visits.add(customer.getLocation().getId());
             }
-            routes.add(new ShallowRoute(depot.getId(), visits));
+            routes.add(new ShallowRoute(vehicle.getId(), depot.getId(), visits));
         }
         return routes;
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtil.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtil.java
@@ -19,6 +19,7 @@ package org.optaweb.vehiclerouting.plugin.planner;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.examples.vehiclerouting.domain.Customer;
@@ -130,11 +131,22 @@ public class SolutionUtil {
     }
 
     /**
+     * Get IDs of vehicles in the solution.
+     * @param solution the solution
+     * @return vehicle IDs
+     */
+    static List<Long> vehicleIds(VehicleRoutingSolution solution) {
+        return solution.getVehicleList().stream()
+                .map(Vehicle::getId)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Get solution's depot ID.
      * @param solution the solution in which to look for the depot
      * @return first depot ID from the solution or {@code null} if there are no depots
      */
-    static Long depot(VehicleRoutingSolution solution) {
+    static Long depotId(VehicleRoutingSolution solution) {
         return solution.getDepotList().isEmpty() ? null : solution.getDepotList().get(0).getId();
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicle.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.planner.change;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
+import org.optaplanner.examples.vehiclerouting.domain.Vehicle;
+import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
+
+public class AddVehicle implements ProblemFactChange<VehicleRoutingSolution> {
+
+    private final Vehicle vehicle;
+
+    public AddVehicle(Vehicle vehicle) {
+        this.vehicle = Objects.requireNonNull(vehicle);
+    }
+
+    @Override
+    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
+        VehicleRoutingSolution workingSolution = scoreDirector.getWorkingSolution();
+        workingSolution.setVehicleList(new ArrayList<>(workingSolution.getVehicleList()));
+
+        scoreDirector.beforeProblemFactAdded(vehicle);
+        workingSolution.getVehicleList().add(vehicle);
+        scoreDirector.afterProblemFactAdded(vehicle);
+
+        scoreDirector.triggerVariableListeners();
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveCustomer.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveCustomer.java
@@ -26,37 +26,37 @@ import org.optaplanner.examples.vehiclerouting.domain.location.Location;
 
 public class RemoveCustomer implements ProblemFactChange<VehicleRoutingSolution> {
 
-    private final Location location;
+    private final Location removedLocation;
 
-    public RemoveCustomer(Location location) {
-        this.location = Objects.requireNonNull(location);
+    public RemoveCustomer(Location removedLocation) {
+        this.removedLocation = Objects.requireNonNull(removedLocation);
     }
 
     @Override
     public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
         VehicleRoutingSolution workingSolution = scoreDirector.getWorkingSolution();
-        Customer customer = workingSolution.getCustomerList().stream()
-                .filter(v -> v.getLocation().getId().equals(location.getId()))
+        Customer removedCustomer = workingSolution.getCustomerList().stream()
+                .filter(customer -> customer.getLocation().getId().equals(removedLocation.getId()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "Invalid request for removing customer at " + location));
+                        "Invalid request for removing customer at " + removedLocation));
 
         // Fix the next customer and set its previousStandstill to the removed customer's previousStandstill
         for (Customer nextCustomer : workingSolution.getCustomerList()) {
-            if (nextCustomer.getPreviousStandstill().equals(customer)) {
+            if (nextCustomer.getPreviousStandstill().equals(removedCustomer)) {
                 scoreDirector.beforeVariableChanged(nextCustomer, "previousStandstill");
-                nextCustomer.setPreviousStandstill(customer.getPreviousStandstill());
+                nextCustomer.setPreviousStandstill(removedCustomer.getPreviousStandstill());
                 scoreDirector.afterVariableChanged(nextCustomer, "previousStandstill");
                 break;
             }
         }
 
         // Remove the customer
-        scoreDirector.beforeEntityRemoved(customer);
-        if (!workingSolution.getCustomerList().remove(customer)) {
+        scoreDirector.beforeEntityRemoved(removedCustomer);
+        if (!workingSolution.getCustomerList().remove(removedCustomer)) {
             throw new IllegalStateException("This is impossible.");
         }
-        scoreDirector.afterEntityRemoved(customer);
+        scoreDirector.afterEntityRemoved(removedCustomer);
 
         scoreDirector.triggerVariableListeners();
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.planner.change;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
+import org.optaplanner.examples.vehiclerouting.domain.Customer;
+import org.optaplanner.examples.vehiclerouting.domain.Vehicle;
+import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
+
+public class RemoveVehicle implements ProblemFactChange<VehicleRoutingSolution> {
+
+    private final Vehicle removedVehicle;
+
+    public RemoveVehicle(Vehicle removedVehicle) {
+        this.removedVehicle = Objects.requireNonNull(removedVehicle);
+    }
+
+    @Override
+    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
+        VehicleRoutingSolution workingSolution = scoreDirector.getWorkingSolution();
+
+        // look up working copy of the vehicle
+        Vehicle workingVehicle = scoreDirector.lookUpWorkingObject(removedVehicle);
+        if (workingVehicle == null) {
+            throw new IllegalStateException("Can't look up working copy of " + removedVehicle);
+        }
+
+        // Un-initialize all customer visited by this vehicle
+        Customer visitedCustomer = workingVehicle.getNextCustomer();
+        while (visitedCustomer != null) {
+            scoreDirector.beforeVariableChanged(visitedCustomer, "previousStandstill");
+            visitedCustomer.setPreviousStandstill(null);
+            scoreDirector.afterVariableChanged(visitedCustomer, "previousStandstill");
+
+            visitedCustomer = visitedCustomer.getNextCustomer();
+        }
+
+        // shallow clone fact list
+        workingSolution.setVehicleList(new ArrayList<>(workingSolution.getVehicleList()));
+        // Remove the vehicle
+        scoreDirector.beforeProblemFactRemoved(workingVehicle);
+        if (!workingSolution.getVehicleList().remove(workingVehicle)) {
+            throw new IllegalStateException("This is a bug.");
+        }
+        scoreDirector.afterProblemFactRemoved(workingVehicle);
+
+        scoreDirector.triggerVariableListeners();
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableCoordinates.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableCoordinates.java
@@ -40,6 +40,7 @@ class PortableCoordinates {
     private final BigDecimal longitude;
 
     static PortableCoordinates fromCoordinates(Coordinates coordinates) {
+        Objects.requireNonNull(coordinates, "coordinates must not be null");
         return new PortableCoordinates(
                 coordinates.latitude(),
                 coordinates.longitude()

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocation.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocation.java
@@ -38,6 +38,7 @@ class PortableLocation {
     private final String description;
 
     static PortableLocation fromLocation(Location location) {
+        Objects.requireNonNull(location, "location must not be null");
         return new PortableLocation(
                 location.id(),
                 location.coordinates().latitude(),

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRoute.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRoute.java
@@ -27,15 +27,26 @@ import org.optaweb.vehiclerouting.domain.Route;
  */
 class PortableRoute {
 
+    private final PortableVehicle vehicle;
     private final PortableLocation depot;
     private final List<PortableLocation> visits;
     @JsonFormat(shape = JsonFormat.Shape.ARRAY)
     private final List<List<PortableCoordinates>> track;
 
-    PortableRoute(PortableLocation depot, List<PortableLocation> visits, List<List<PortableCoordinates>> track) {
+    PortableRoute(
+            PortableVehicle vehicle,
+            PortableLocation depot,
+            List<PortableLocation> visits,
+            List<List<PortableCoordinates>> track
+    ) {
+        this.vehicle = Objects.requireNonNull(vehicle);
         this.depot = Objects.requireNonNull(depot);
         this.visits = Objects.requireNonNull(visits);
         this.track = Objects.requireNonNull(track);
+    }
+
+    public PortableVehicle getVehicle() {
+        return vehicle;
     }
 
     public PortableLocation getDepot() {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRoutingPlan.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRoutingPlan.java
@@ -26,11 +26,19 @@ import org.optaweb.vehiclerouting.domain.RoutingPlan;
 class PortableRoutingPlan {
 
     private final String distance;
+    private final List<PortableVehicle> vehicles;
     private final PortableLocation depot;
     private final List<PortableRoute> routes;
 
-    PortableRoutingPlan(String distance, PortableLocation depot, List<PortableRoute> routes) {
+    PortableRoutingPlan(
+            String distance,
+            List<PortableVehicle> vehicles,
+            PortableLocation depot,
+            List<PortableRoute> routes
+    ) {
+        // TODO require non-null
         this.distance = distance;
+        this.vehicles = vehicles;
         this.depot = depot;
         this.routes = routes;
     }
@@ -39,11 +47,15 @@ class PortableRoutingPlan {
         return distance;
     }
 
-    public List<PortableRoute> getRoutes() {
-        return routes;
+    public List<PortableVehicle> getVehicles() {
+        return vehicles;
     }
 
     public PortableLocation getDepot() {
         return depot;
+    }
+
+    public List<PortableRoute> getRoutes() {
+        return routes;
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableVehicle.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import org.optaweb.vehiclerouting.domain.Vehicle;
 
 /**
- * Vehicle representation suitable for network transport.
+ * {@link Vehicle} representation suitable for network transport.
  */
 class PortableVehicle {
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableVehicle.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.websocket;
+
+import java.util.Objects;
+
+import org.optaweb.vehiclerouting.domain.Vehicle;
+
+/**
+ * Vehicle representation suitable for network transport.
+ */
+class PortableVehicle {
+
+    private final long id;
+    private final String name;
+
+    static PortableVehicle fromVehicle(Vehicle vehicle) {
+        Objects.requireNonNull(vehicle, "vehicle must not be null");
+        return new PortableVehicle(vehicle.id(), vehicle.name());
+    }
+
+    PortableVehicle(long id, String name) {
+        this.id = id;
+        this.name = Objects.requireNonNull(name);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PortableVehicle vehicle = (PortableVehicle) o;
+        return id == vehicle.id &&
+                name.equals(vehicle.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "PortableVehicle{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImpl.java
@@ -50,6 +50,7 @@ class RoutePublisherImpl implements RoutePublisher {
         PortableLocation depot = routingPlan.depot().map(PortableLocation::fromLocation).orElse(null);
         List<PortableRoute> routes = routingPlan.routes().stream()
                 .map(routeWithTrack -> new PortableRoute(
+                        PortableVehicle.fromVehicle(routeWithTrack.vehicle()),
                         depot,
                         portableVisits(routeWithTrack.visits()),
                         portableTrack(routeWithTrack.track())))

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImpl.java
@@ -47,6 +47,9 @@ class RoutePublisherImpl implements RoutePublisher {
     }
 
     static PortableRoutingPlan portable(RoutingPlan routingPlan) {
+        List<PortableVehicle> vehicles = routingPlan.vehicles().stream()
+                .map(PortableVehicle::fromVehicle)
+                .collect(Collectors.toList());
         PortableLocation depot = routingPlan.depot().map(PortableLocation::fromLocation).orElse(null);
         List<PortableRoute> routes = routingPlan.routes().stream()
                 .map(routeWithTrack -> new PortableRoute(
@@ -55,7 +58,7 @@ class RoutePublisherImpl implements RoutePublisher {
                         portableVisits(routeWithTrack.visits()),
                         portableTrack(routeWithTrack.track())))
                 .collect(Collectors.toList());
-        return new PortableRoutingPlan(routingPlan.distance(), depot, routes);
+        return new PortableRoutingPlan(routingPlan.distance(), vehicles, depot, routes);
     }
 
     private static List<List<PortableCoordinates>> portableTrack(List<List<Coordinates>> track) {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketController.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketController.java
@@ -128,4 +128,13 @@ class WebSocketController {
     void addVehicle() {
         vehicleService.addVehicle();
     }
+
+    /**
+     * Delete vehicle.
+     * @param id ID of the vehicle to be deleted
+     */
+    @MessageMapping({"/vehicle/{id}/delete"})
+    void removeVehicle(@DestinationVariable Long id) {
+        vehicleService.removeVehicle(id);
+    }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketController.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketController.java
@@ -27,6 +27,7 @@ import org.optaweb.vehiclerouting.service.location.LocationService;
 import org.optaweb.vehiclerouting.service.region.BoundingBox;
 import org.optaweb.vehiclerouting.service.region.RegionService;
 import org.optaweb.vehiclerouting.service.route.RouteListener;
+import org.optaweb.vehiclerouting.service.vehicle.VehicleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -43,16 +44,20 @@ class WebSocketController {
     private final RouteListener routeListener;
     private final RegionService regionService;
     private final LocationService locationService;
+    private final VehicleService vehicleService;
     private final DemoService demoService;
 
     @Autowired
     WebSocketController(RouteListener routeListener,
                         RegionService regionService,
                         LocationService locationService,
-                        DemoService demoService) {
+                        VehicleService vehicleService,
+                        DemoService demoService
+    ) {
         this.routeListener = routeListener;
         this.regionService = regionService;
         this.locationService = locationService;
+        this.vehicleService = vehicleService;
         this.demoService = demoService;
     }
 
@@ -117,5 +122,10 @@ class WebSocketController {
     @MessageMapping("/clear")
     void clear() {
         locationService.clear();
+    }
+
+    @MessageMapping({"vehicle"})
+    void addVehicle() {
+        vehicleService.addVehicle();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/location/LocationService.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/location/LocationService.java
@@ -22,8 +22,6 @@ import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 /**
@@ -46,16 +44,15 @@ public class LocationService {
         this.distanceMatrix = distanceMatrix;
     }
 
-    @EventListener
-    public synchronized void reload(ApplicationStartedEvent event) {
-        repository.locations().forEach(this::submitToPlanner);
-    }
-
     public synchronized boolean createLocation(Coordinates coordinates, String description) {
         Objects.requireNonNull(coordinates);
         Objects.requireNonNull(description);
         // TODO if (router.isLocationAvailable(coordinates))
         return submitToPlanner(repository.createLocation(coordinates, description));
+    }
+
+    public synchronized boolean addLocation(Location location) {
+        return submitToPlanner(Objects.requireNonNull(location));
     }
 
     private boolean submitToPlanner(Location location) {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/location/RouteOptimizer.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/location/RouteOptimizer.java
@@ -31,4 +31,6 @@ public interface RouteOptimizer {
     void clear();
 
     void addVehicle(Vehicle vehicle);
+
+    void removeVehicle(Vehicle vehicle);
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/location/RouteOptimizer.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/location/RouteOptimizer.java
@@ -17,6 +17,7 @@
 package org.optaweb.vehiclerouting.service.location;
 
 import org.optaweb.vehiclerouting.domain.Location;
+import org.optaweb.vehiclerouting.domain.Vehicle;
 
 /**
  * Performs route optimization based on distances provided by {@link DistanceMatrix}.
@@ -28,4 +29,6 @@ public interface RouteOptimizer {
     void removeLocation(Location location);
 
     void clear();
+
+    void addVehicle(Vehicle vehicle);
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/reload/ReloadService.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/reload/ReloadService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.reload;
+
+import org.optaweb.vehiclerouting.service.location.LocationRepository;
+import org.optaweb.vehiclerouting.service.location.LocationService;
+import org.optaweb.vehiclerouting.service.vehicle.VehicleService;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReloadService {
+
+    private final VehicleService vehicleService;
+    private final LocationRepository locationRepository;
+    private final LocationService locationService;
+
+    ReloadService(
+            VehicleService vehicleService,
+            LocationRepository locationRepository,
+            LocationService locationService
+    ) {
+        this.vehicleService = vehicleService;
+        this.locationRepository = locationRepository;
+        this.locationService = locationService;
+    }
+
+    @EventListener
+    public synchronized void reload(ApplicationStartedEvent event) {
+        for (int i = 0; i < 6; i++) {
+            vehicleService.addVehicle();
+        }
+        locationRepository.locations().forEach(locationService::addLocation);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteChangedEvent.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteChangedEvent.java
@@ -56,6 +56,10 @@ public class RouteChangedEvent extends ApplicationEvent {
         this.routes = Objects.requireNonNull(routes);
     }
 
+    /**
+     * IDs of all vehicles.
+     * @return vehicle IDs
+     */
     public List<Long> vehicleIds() {
         return vehicleIds;
     }
@@ -76,7 +80,7 @@ public class RouteChangedEvent extends ApplicationEvent {
      * The depot ID.
      * @return depot ID
      */
-    public Optional<Long> depot() {
+    public Optional<Long> depotId() {
         return Optional.ofNullable(depotId);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteChangedEvent.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteChangedEvent.java
@@ -17,6 +17,7 @@
 package org.optaweb.vehiclerouting.service.route;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -29,6 +30,7 @@ import org.springframework.context.ApplicationEvent;
 public class RouteChangedEvent extends ApplicationEvent {
 
     private final String distance;
+    private final List<Long> vehicleIds;
     private final Long depotId;
     private final Collection<ShallowRoute> routes;
 
@@ -36,14 +38,26 @@ public class RouteChangedEvent extends ApplicationEvent {
      * Create a new ApplicationEvent.
      * @param source the object on which the event initially occurred (never {@code null})
      * @param distance total distance of all vehicle routes
+     * @param vehicleIds vehicle IDs
      * @param depotId depot ID. May be null if there are no locations.
      * @param routes vehicle routes
      */
-    public RouteChangedEvent(Object source, String distance, Long depotId, Collection<ShallowRoute> routes) {
+    public RouteChangedEvent(
+            Object source,
+            String distance,
+            List<Long> vehicleIds,
+            Long depotId,
+            Collection<ShallowRoute> routes
+    ) {
         super(source);
         this.distance = Objects.requireNonNull(distance);
-        this.depotId = depotId;
+        this.vehicleIds = Objects.requireNonNull(vehicleIds);
+        this.depotId = depotId; // may be null (no depot)
         this.routes = Objects.requireNonNull(routes);
+    }
+
+    public List<Long> vehicleIds() {
+        return vehicleIds;
     }
 
     /**

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteChangedEvent.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteChangedEvent.java
@@ -23,8 +23,8 @@ import java.util.Optional;
 import org.springframework.context.ApplicationEvent;
 
 /**
- * Event published when the routing plan has been updated either by discovering a better route or by changing
- * the set of locations.
+ * Event published when the routing plan has been updated either by discovering a better route or by a change
+ * in the problem specification (vehicles, visits).
  */
 public class RouteChangedEvent extends ApplicationEvent {
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
@@ -69,7 +69,7 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
         // TODO persist the best solution
         Map<Long, Vehicle> vehicleMap = event.vehicleIds().stream()
                 .collect(Collectors.toMap(vehicleId -> vehicleId, this::findVehicleById));
-        Location depot = event.depot().flatMap(locationRepository::find).orElse(null);
+        Location depot = event.depotId().flatMap(locationRepository::find).orElse(null);
         try {
             List<RouteWithTrack> routes = event.routes().stream()
                     // list of deep locations

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
@@ -26,6 +26,7 @@ import org.optaweb.vehiclerouting.domain.Location;
 import org.optaweb.vehiclerouting.domain.Route;
 import org.optaweb.vehiclerouting.domain.RouteWithTrack;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
+import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.optaweb.vehiclerouting.service.location.LocationRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,7 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
             List<RouteWithTrack> routes = event.routes().stream()
                     // list of deep locations
                     .map(shallowRoute -> new Route(
+                            findVehicleById(shallowRoute.vehicleId),
                             findLocationById(shallowRoute.depotId),
                             shallowRoute.visitIds.stream()
                                     .map(this::findLocationById)
@@ -75,6 +77,11 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
         } catch (IllegalStateException e) {
             logger.warn("Discarding an outdated routing plan: {}", e.toString());
         }
+    }
+
+    private static Vehicle findVehicleById(Long id) {
+        // TODO retrieve vehicle from the repository
+        return new Vehicle(id, "Vehicle " + id);
     }
 
     private Location findLocationById(Long id) {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
@@ -28,6 +28,7 @@ import org.optaweb.vehiclerouting.domain.RouteWithTrack;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
 import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.optaweb.vehiclerouting.service.location.LocationRepository;
+import org.optaweb.vehiclerouting.service.vehicle.VehicleRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
@@ -43,14 +44,21 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
 
     private final Router router;
     private final RoutePublisher publisher;
+    private final VehicleRepository vehicleRepository;
     private final LocationRepository locationRepository;
 
     // TODO maybe remove state from the service and get best route from a repository
     private RoutingPlan bestRoutingPlan;
 
-    RouteListener(Router router, RoutePublisher publisher, LocationRepository locationRepository) {
+    RouteListener(
+            Router router,
+            RoutePublisher publisher,
+            VehicleRepository vehicleRepository,
+            LocationRepository locationRepository
+    ) {
         this.router = router;
         this.publisher = publisher;
+        this.vehicleRepository = vehicleRepository;
         this.locationRepository = locationRepository;
         bestRoutingPlan = RoutingPlan.empty();
     }
@@ -79,9 +87,10 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
         }
     }
 
-    private static Vehicle findVehicleById(Long id) {
-        // TODO retrieve vehicle from the repository
-        return new Vehicle(id, "Vehicle " + id);
+    private Vehicle findVehicleById(Long id) {
+        return vehicleRepository.find(id).orElseThrow(() -> new IllegalStateException(
+                "Vehicle {id=" + id + "} not found in the repository")
+        );
     }
 
     private Location findLocationById(Long id) {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/ShallowRoute.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/ShallowRoute.java
@@ -37,6 +37,10 @@ import java.util.stream.Stream;
 public class ShallowRoute {
 
     /**
+     * Vehicle ID (never {@code null}).
+     */
+    public final Long vehicleId;
+    /**
      * Depot ID (never {@code null}).
      */
     public final Long depotId;
@@ -47,18 +51,21 @@ public class ShallowRoute {
 
     /**
      * Create shallow route.
+     * @param vehicleId vehicle ID (never {@code null})
      * @param depotId depot ID (never {@code null})
      * @param visitIds visit IDs
      */
-    public ShallowRoute(Long depotId, List<Long> visitIds) {
+    public ShallowRoute(Long vehicleId, Long depotId, List<Long> visitIds) {
+        this.vehicleId = Objects.requireNonNull(vehicleId);
         this.depotId = Objects.requireNonNull(depotId);
         this.visitIds = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(visitIds)));
     }
 
     @Override
     public String toString() {
-        return Stream.concat(Stream.of(depotId), visitIds.stream())
+        String route = Stream.concat(Stream.of(depotId), visitIds.stream())
                 .map(Object::toString)
                 .collect(Collectors.joining("->", "[", "]"));
+        return vehicleId + ": " + route;
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/ShallowRoute.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/ShallowRoute.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 // because then we can hold a reference to the original location
 
 /**
- * Lightweight route description consisting of location IDs instead of entities.
+ * Lightweight route description consisting of vehicle and location IDs instead of entities.
  * This makes it easier to quickly construct and share result of route optimization
  * without converting planning domain objects to business domain objects.
  * Specifically, some information may be lost when converting business domain objects to planning domain

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleRepository.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleRepository.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.vehicle;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.optaweb.vehiclerouting.domain.Vehicle;
+
+/**
+ * Defines repository operations on vehicles.
+ */
+public interface VehicleRepository {
+
+    /**
+     * Create a vehicle with a unique ID.
+     * @param name vehicle name
+     * @return a new vehicle
+     */
+    Vehicle createVehicle(String name);
+
+    /**
+     * Get all vehicles.
+     * @return all vehicles
+     */
+    List<Vehicle> vehicles();
+
+    /**
+     * Remove vehicle.
+     * @param id vehicle's id
+     * @return the removed vehicle
+     */
+    Vehicle removeVehicle(long id);
+
+    /**
+     * Remove all vehicles from the repository.
+     */
+    void removeAll();
+
+    Optional<Vehicle> find(Long vehicleId);
+
+    /**
+     * Temporary hack needed for vehicle name auto-generation.
+     * @return unique ID that will be used for the next new vehicle.
+     */
+    long nextId();
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleRepositoryImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleRepositoryImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.vehicle;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.optaweb.vehiclerouting.domain.Vehicle;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VehicleRepositoryImpl implements VehicleRepository {
+
+    private long idSequence = 0;
+    private Map<Long, Vehicle> vehicles = new HashMap<>(10);
+
+    @Override
+    public Vehicle createVehicle(String name) {
+        Vehicle vehicle = new Vehicle(idSequence++, name);
+        vehicles.put(vehicle.id(), vehicle);
+        return vehicle;
+    }
+
+    @Override
+    public List<Vehicle> vehicles() {
+        return Collections.unmodifiableList(
+                vehicles.values().stream()
+                        .sorted((o1, o2) -> Long.signum(o2.id() - o1.id()))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Vehicle removeVehicle(long id) {
+        return vehicles.remove(id);
+    }
+
+    @Override
+    public void removeAll() {
+        vehicles.clear();
+    }
+
+    @Override
+    public Optional<Vehicle> find(Long vehicleId) {
+        return Optional.ofNullable(vehicles.get(vehicleId));
+    }
+
+    @Override
+    public long nextId() {
+        return idSequence;
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleService.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.vehicle;
+
+import org.optaweb.vehiclerouting.domain.Vehicle;
+import org.optaweb.vehiclerouting.service.location.RouteOptimizer;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VehicleService {
+
+    private final RouteOptimizer optimizer;
+    private final VehicleRepository vehicleRepository;
+
+    public VehicleService(RouteOptimizer optimizer, VehicleRepository vehicleRepository) {
+        this.optimizer = optimizer;
+        this.vehicleRepository = vehicleRepository;
+    }
+
+    public void addVehicle() {
+        long id = vehicleRepository.nextId();
+        Vehicle vehicle = vehicleRepository.createVehicle("Vehicle " + id);
+        optimizer.addVehicle(vehicle);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleService.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/vehicle/VehicleService.java
@@ -36,4 +36,9 @@ public class VehicleService {
         Vehicle vehicle = vehicleRepository.createVehicle("Vehicle " + id);
         optimizer.addVehicle(vehicle);
     }
+
+    public void removeVehicle(long vehicleId) {
+        Vehicle vehicle = vehicleRepository.removeVehicle(vehicleId);
+        optimizer.removeVehicle(vehicle);
+    }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteTest.java
@@ -28,30 +28,32 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 class RouteTest {
 
+    private final Vehicle vehicle = new Vehicle(4, "Test vehicle");
     private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
     private final Location visit1 = new Location(2, Coordinates.valueOf(5, 5));
     private final Location visit2 = new Location(3, Coordinates.valueOf(5, 5));
 
     @Test
     void constructor_args_not_null() {
-        assertThatNullPointerException().isThrownBy(() -> new Route(depot, null));
-        assertThatNullPointerException().isThrownBy(() -> new Route(null, Collections.emptyList()));
+        assertThatNullPointerException().isThrownBy(() -> new Route(null, depot, Collections.emptyList()));
+        assertThatNullPointerException().isThrownBy(() -> new Route(vehicle, null, Collections.emptyList()));
+        assertThatNullPointerException().isThrownBy(() -> new Route(vehicle, depot, null));
     }
 
     @Test
     void visits_should_not_contain_depot() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new Route(depot, Arrays.asList(depot, visit1)))
+                .isThrownBy(() -> new Route(vehicle, depot, Arrays.asList(depot, visit1)))
                 .withMessageContaining(depot.toString());
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new Route(depot, Arrays.asList(visit1, depot, visit2)))
+                .isThrownBy(() -> new Route(vehicle, depot, Arrays.asList(visit1, depot, visit2)))
                 .withMessageContaining(depot.toString());
     }
 
     @Test
     void no_customer_should_be_visited_twice_by_the_same_vehicle() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new Route(depot, Arrays.asList(visit1, visit1)))
+                .isThrownBy(() -> new Route(vehicle, depot, Arrays.asList(visit1, visit1)))
                 .withMessageContaining("(1)");
     }
 
@@ -59,7 +61,7 @@ class RouteTest {
     void cannot_modify_visits_externally() {
         ArrayList<Location> visits = new ArrayList<>();
         visits.add(visit1);
-        Route route = new Route(depot, visits);
+        Route route = new Route(vehicle, depot, visits);
 
         assertThatExceptionOfType(UnsupportedOperationException.class)
                 .isThrownBy(() -> route.visits().clear());

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteWithTrackTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteWithTrackTest.java
@@ -29,20 +29,21 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 class RouteWithTrackTest {
 
+    private final Vehicle vehicle = new Vehicle(4, "Test vehicle");
     private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
     private final Location visit1 = new Location(2, Coordinates.valueOf(5, 5));
     private final Location visit2 = new Location(3, Coordinates.valueOf(5, 5));
 
     @Test
     void constructor_args_not_null() {
-        Route route = new Route(depot, emptyList());
+        Route route = new Route(vehicle, depot, emptyList());
         assertThatNullPointerException().isThrownBy(() -> new RouteWithTrack(route, null));
-        assertThatNullPointerException().isThrownBy(() -> new Route(null, emptyList()));
+        assertThatNullPointerException().isThrownBy(() -> new RouteWithTrack(null, emptyList()));
     }
 
     @Test
     void cannot_modify_track_externally() {
-        Route route = new Route(depot, Arrays.asList(visit1, visit2));
+        Route route = new Route(vehicle, depot, Arrays.asList(visit1, visit2));
         ArrayList<List<Coordinates>> track = new ArrayList<>();
         track.add(Arrays.asList(Coordinates.valueOf(1.0, 2.0)));
 
@@ -53,7 +54,7 @@ class RouteWithTrackTest {
 
     @Test
     void when_route_is_empty_track_must_be_empty() {
-        Route emptyRoute = new Route(depot, emptyList());
+        Route emptyRoute = new Route(vehicle, depot, emptyList());
         ArrayList<List<Coordinates>> track = new ArrayList<>();
         track.add(Arrays.asList(Coordinates.valueOf(1.0, 2.0)));
 
@@ -62,7 +63,7 @@ class RouteWithTrackTest {
 
     @Test
     void when_route_is_nonempty_track_must_be_nonempty() {
-        Route route = new Route(depot, Arrays.asList(visit1, visit2));
+        Route route = new Route(vehicle, depot, Arrays.asList(visit1, visit2));
         ArrayList<List<Coordinates>> emptyTrack = new ArrayList<>();
 
         assertThatIllegalArgumentException().isThrownBy(() -> new RouteWithTrack(route, emptyTrack));

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -76,5 +77,22 @@ class RoutingPlanTest {
                 .isThrownBy(() -> routingPlan.routes().clear());
         assertThatExceptionOfType(UnsupportedOperationException.class)
                 .isThrownBy(() -> routingPlan.vehicles().clear());
+    }
+
+    @Test
+    void empty_routing_plan_should_be_empty() {
+        RoutingPlan empty = RoutingPlan.empty();
+        assertThat(empty.distance()).isEmpty();
+        assertThat(empty.vehicles()).isEmpty();
+        assertThat(empty.depot()).isEmpty();
+        assertThat(empty.routes()).isEmpty();
+    }
+
+    @Test
+    void isEmpty() {
+        assertThat(RoutingPlan.empty().isEmpty()).isTrue();
+        assertThat(new RoutingPlan("", emptyList(), depot, emptyList()).isEmpty()).isFalse();
+        assertThat(new RoutingPlan("", vehicles, null, emptyList()).isEmpty()).isFalse();
+        assertThat(new RoutingPlan("", vehicles, depot, singletonList(emptyRoute)).isEmpty()).isFalse();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
@@ -28,8 +28,9 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 class RoutingPlanTest {
 
+    private final Vehicle vehicle = new Vehicle(1, "V");
     private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
-    private final RouteWithTrack emptyRoute = new RouteWithTrack(new Route(depot, emptyList()), emptyList());
+    private final RouteWithTrack emptyRoute = new RouteWithTrack(new Route(vehicle, depot, emptyList()), emptyList());
 
     @Test
     void constructor_args_not_null() {

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
@@ -17,11 +17,12 @@
 package org.optaweb.vehiclerouting.domain;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -29,27 +30,51 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 class RoutingPlanTest {
 
     private final Vehicle vehicle = new Vehicle(1, "V");
+    private final List<Vehicle> vehicles = singletonList(vehicle);
     private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
     private final RouteWithTrack emptyRoute = new RouteWithTrack(new Route(vehicle, depot, emptyList()), emptyList());
 
     @Test
     void constructor_args_not_null() {
-        assertThatNullPointerException().isThrownBy(() -> new RoutingPlan(null, depot, emptyList()));
-        assertThatNullPointerException().isThrownBy(() -> new RoutingPlan("", depot, null));
+        assertThatNullPointerException().isThrownBy(() -> new RoutingPlan(null, vehicles, depot, emptyList()));
+        assertThatNullPointerException().isThrownBy(() -> new RoutingPlan("", null, depot, emptyList()));
+        assertThatNullPointerException().isThrownBy(() -> new RoutingPlan("", vehicles, depot, null));
+        // depot can be null
+        // TODO create a factory that will prevent passing a null depot accidentally
     }
 
     @Test
     void no_routes_without_a_depot() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new RoutingPlan("", null, Arrays.asList(emptyRoute)));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RoutingPlan("", vehicles, null, singletonList(emptyRoute)));
+    }
+
+    @Test
+    void there_must_be_one_route_per_vehicle_when_there_is_a_depot() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RoutingPlan("", vehicles, depot, emptyList()))
+                .withMessageContaining("Vehicles (1): [")
+                .withMessageContaining("Routes' vehicleIds (0): []");
+    }
+
+    @Test
+    void routes_vehicle_references_must_be_consistent_with_vehicles_in_routing_plan() {
+        List<Vehicle> newVehicles = singletonList(new Vehicle(vehicle.id() + 1, ""));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RoutingPlan("", newVehicles, depot, singletonList(emptyRoute)))
+                .withMessageContaining("Vehicles (1): [")
+                .withMessageContaining("Routes' vehicleIds (1): [" + vehicle.id() + "]");
     }
 
     @Test
     void cannot_modify_routes_externally() {
         ArrayList<RouteWithTrack> routes = new ArrayList<>();
         routes.add(emptyRoute);
-        RoutingPlan routingPlan = new RoutingPlan("", depot, routes);
+        RoutingPlan routingPlan = new RoutingPlan("", vehicles, depot, routes);
 
         assertThatExceptionOfType(UnsupportedOperationException.class)
                 .isThrownBy(() -> routingPlan.routes().clear());
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> routingPlan.vehicles().clear());
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/VehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/VehicleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class VehicleTest {
+
+    @Test
+    void constructor_params_must_not_be_null() {
+        assertThatNullPointerException().isThrownBy(() -> new Vehicle(0, null));
+    }
+
+    @Test
+    void vehicles_are_identified_based_on_id() {
+        final String description = "test description";
+        final long id = 0;
+        final Vehicle vehicle = new Vehicle(id, description);
+
+        // different ID
+        assertThat(vehicle).isNotEqualTo(new Vehicle(id + 1, description));
+        // null
+        assertThat(vehicle).isNotEqualTo(null);
+        // different class
+        assertThat(vehicle).isNotEqualTo(id);
+        // same object -> OK
+        assertThat(vehicle).isEqualTo(vehicle);
+        // same properties -> OK
+        assertThat(vehicle).isEqualTo(new Vehicle(id, description));
+        // same ID, different description -> OK
+        assertThat(vehicle).isEqualTo(new Vehicle(id, description + "x"));
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImplTest.java
@@ -140,9 +140,7 @@ class RouteOptimizerImplTest {
 
         routeOptimizer.bestSolutionChanged(bestSolutionChangedEvent);
 
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event = routeChangedEventArgumentCaptor.getValue();
-
+        RouteChangedEvent event = verifyAndCaptureEvent();
         assertThat(event.vehicleIds()).containsExactly(vehicleId);
         assertThat(event.depotId()).contains(location1.id());
         assertThat(event.routes()).hasSize(1);
@@ -164,9 +162,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addLocation(location1, distanceMatrix);
 
         // assert
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event = routeChangedEventArgumentCaptor.getValue();
-
+        RouteChangedEvent event = verifyAndCaptureEvent();
         assertThat(solver.isSolving()).isFalse();
         assertThat(event.vehicleIds()).containsExactlyInAnyOrder(vehicleIds);
         assertThat(event.depotId()).contains(location1.id());
@@ -187,9 +183,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addVehicle(vehicle(vehicleId1));
 
         // assert
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event = routeChangedEventArgumentCaptor.getValue();
-
+        RouteChangedEvent event = verifyAndCaptureEvent();
         assertThat(solver.isSolving()).isFalse();
         assertThat(event.vehicleIds()).containsExactly(vehicleId1);
         assertThat(event.depotId()).isEmpty();
@@ -264,10 +258,8 @@ class RouteOptimizerImplTest {
         routeOptimizer.removeLocation(location2);
         assertThat(routeOptimizer.isSolving()).isFalse();
 
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event = routeChangedEventArgumentCaptor.getValue();
-
         // no customer -> all routes should be empty
+        RouteChangedEvent event = verifyAndCaptureEvent();
         assertThat(event.distance()).isEqualTo("0h 0m 0s"); // expect zero travel distance
         assertThat(event.vehicleIds()).containsExactlyInAnyOrder(vehicleId1, vehicleId2);
         assertThat(event.depotId()).isPresent();
@@ -301,9 +293,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addLocation(location1, distanceMatrix);
 
         // then all vehicles must be in the depot
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event1 = routeChangedEventArgumentCaptor.getValue();
-
+        RouteChangedEvent event1 = verifyAndCaptureEvent();
         assertThat(event1.vehicleIds()).containsExactlyInAnyOrder(vehicleId1, vehicleId2);
         // NOTE: can't verify that vehicle.getDepot() == depot for each vehicle because that's internal
         // to the optimizer. Neither VehicleRoutingSolution nor any other planning domain classes are exposed
@@ -319,9 +309,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.removeLocation(location1);
 
         // then published event's depot value is empty
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event2 = routeChangedEventArgumentCaptor.getValue();
-
+        RouteChangedEvent event2 = verifyAndCaptureEvent();
         assertThat(event2.vehicleIds()).containsExactlyInAnyOrder(vehicleId1, vehicleId2);
         assertThat(event2.depotId()).isEmpty();
         assertThat(event2.routes()).isEmpty();
@@ -377,8 +365,7 @@ class RouteOptimizerImplTest {
         verify(solver).terminateEarly();
         verify(solverFuture).get();
 
-        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
-        RouteChangedEvent event = routeChangedEventArgumentCaptor.getValue();
+        RouteChangedEvent event = verifyAndCaptureEvent();
         assertThat(event.vehicleIds()).isEmpty();
         assertThat(event.depotId()).isEmpty();
         assertThat(event.routes()).isEmpty();
@@ -412,6 +399,11 @@ class RouteOptimizerImplTest {
         assertThat(roadLocation.getId()).isEqualTo(location1.id());
         assertThat(roadLocation.getLatitude()).isEqualTo(location1.coordinates().latitude().doubleValue());
         assertThat(roadLocation.getLongitude()).isEqualTo(location1.coordinates().longitude().doubleValue());
+    }
+
+    private RouteChangedEvent verifyAndCaptureEvent() {
+        verify(eventPublisher).publishEvent(routeChangedEventArgumentCaptor.capture());
+        return routeChangedEventArgumentCaptor.getValue();
     }
 
     /**

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtilTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolutionUtilTest.java
@@ -95,8 +95,10 @@ class SolutionUtilTest {
     @Test
     void initialized_solution_should_have_one_route_per_vehicle() {
         VehicleRoutingSolution solution = SolutionUtil.emptySolution();
-        SolutionUtil.addVehicle(solution, 1);
-        SolutionUtil.addVehicle(solution, 2);
+        long vehicleId1 = 1001;
+        long vehicleId2 = 2001;
+        SolutionUtil.addVehicle(solution, vehicleId1);
+        SolutionUtil.addVehicle(solution, vehicleId2);
 
         Depot depot = SolutionUtil.addDepot(solution, new RoadLocation(1, 1.0, 1.0));
         Customer customer = SolutionUtil.addCustomer(solution, new RoadLocation(2, 2.0, 2.0));
@@ -109,6 +111,8 @@ class SolutionUtilTest {
 
         List<ShallowRoute> routes = SolutionUtil.routes(solution);
         assertThat(routes).hasSameSizeAs(solution.getVehicleList());
+        assertThat(routes.stream().mapToLong(value -> value.vehicleId))
+                .containsExactlyInAnyOrder(vehicleId1, vehicleId2);
 
         for (ShallowRoute route : routes) {
             assertThat(route.depotId).isEqualTo(depot.getId());

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicleTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.planner.change;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.examples.vehiclerouting.domain.Vehicle;
+import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
+import org.optaweb.vehiclerouting.plugin.planner.SolutionUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddVehicleTest {
+
+    @Mock
+    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
+
+    @Test
+    void add_vehicle_should_add_vehicle() {
+        VehicleRoutingSolution solution = SolutionUtil.emptySolution();
+        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
+
+        Vehicle vehicle = new Vehicle();
+        AddVehicle addVehicle = new AddVehicle(vehicle);
+        addVehicle.doChange(scoreDirector);
+
+        assertThat(solution.getVehicleList()).containsExactly(vehicle);
+
+        verify(scoreDirector).beforeProblemFactAdded(vehicle);
+        verify(scoreDirector).afterProblemFactAdded(vehicle);
+        verify(scoreDirector).triggerVariableListeners();
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicleTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.planner.change;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.examples.vehiclerouting.domain.Customer;
+import org.optaplanner.examples.vehiclerouting.domain.Depot;
+import org.optaplanner.examples.vehiclerouting.domain.Vehicle;
+import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
+import org.optaplanner.examples.vehiclerouting.domain.location.Location;
+import org.optaplanner.examples.vehiclerouting.domain.location.RoadLocation;
+import org.optaweb.vehiclerouting.plugin.planner.SolutionUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveVehicleTest {
+
+    @Mock
+    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
+
+    @Test
+    void remove_vehicle() {
+        VehicleRoutingSolution solution = SolutionUtil.emptySolution();
+        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
+
+        Location location = new RoadLocation(1, 2.0, 3.0);
+        Depot depot = new Depot();
+        depot.setLocation(location);
+
+        Vehicle removedVehicle = new Vehicle();
+        removedVehicle.setId(1L);
+        removedVehicle.setDepot(depot);
+        Vehicle otherVehicle = new Vehicle();
+        otherVehicle.setId(2L);
+        otherVehicle.setDepot(depot);
+        solution.getVehicleList().add(removedVehicle);
+        solution.getVehicleList().add(otherVehicle);
+
+        when(scoreDirector.lookUpWorkingObject(removedVehicle)).thenReturn(removedVehicle);
+
+        Customer firstCustomer = customer(1);
+        Customer lastCustomer = customer(2);
+        solution.getCustomerList().add(firstCustomer);
+        solution.getCustomerList().add(lastCustomer);
+
+        // V -> first -> last
+        removedVehicle.setNextCustomer(firstCustomer);
+        firstCustomer.setPreviousStandstill(removedVehicle);
+        firstCustomer.setVehicle(removedVehicle);
+        firstCustomer.setNextCustomer(lastCustomer);
+        lastCustomer.setPreviousStandstill(firstCustomer);
+        lastCustomer.setVehicle(removedVehicle);
+
+        // do change
+        RemoveVehicle removeVehicle = new RemoveVehicle(removedVehicle);
+        removeVehicle.doChange(scoreDirector);
+
+        assertThat(firstCustomer.getPreviousStandstill()).isNull();
+        assertThat(lastCustomer.getPreviousStandstill()).isNull();
+        assertThat(solution.getVehicleList()).containsExactly(otherVehicle);
+
+        verify(scoreDirector).beforeVariableChanged(firstCustomer, "previousStandstill");
+        verify(scoreDirector).afterVariableChanged(firstCustomer, "previousStandstill");
+        verify(scoreDirector).beforeVariableChanged(lastCustomer, "previousStandstill");
+        verify(scoreDirector).afterVariableChanged(lastCustomer, "previousStandstill");
+        verify(scoreDirector).beforeProblemFactRemoved(any(Vehicle.class));
+        verify(scoreDirector).afterProblemFactRemoved(any(Vehicle.class));
+        verify(scoreDirector).triggerVariableListeners();
+    }
+
+    private static Customer customer(long id) {
+        Location location = new RoadLocation(1000000 + id, id, id);
+        Customer customer = new Customer();
+        customer.setId(id);
+        customer.setLocation(location);
+        return customer;
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableCoordinatesTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableCoordinatesTest.java
@@ -26,6 +26,7 @@ import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.springframework.boot.test.json.JacksonTester;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 class PortableCoordinatesTest {
 
@@ -53,6 +54,10 @@ class PortableCoordinatesTest {
         PortableCoordinates portableCoordinates = PortableCoordinates.fromCoordinates(coordinates);
         assertThat(portableCoordinates.getLatitude()).isEqualTo(coordinates.latitude());
         assertThat(portableCoordinates.getLongitude()).isEqualTo(coordinates.longitude());
+
+        assertThatNullPointerException()
+                .isThrownBy(() -> PortableCoordinates.fromCoordinates(null))
+                .withMessageContaining("coordinates");
     }
 
     @Test

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableLocationTest.java
@@ -73,6 +73,10 @@ class PortableLocationTest {
         assertThat(portableLocation.getLatitude()).isEqualTo(location.coordinates().latitude());
         assertThat(portableLocation.getLongitude()).isEqualTo(location.coordinates().longitude());
         assertThat(portableLocation.getDescription()).isEqualTo(location.description());
+
+        assertThatNullPointerException()
+                .isThrownBy(() -> PortableLocation.fromLocation(null))
+                .withMessageContaining("location");
     }
 
     @Test

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRouteTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRouteTest.java
@@ -42,11 +42,13 @@ class PortableRouteTest {
 
     @Test
     void marshal_to_json() throws IOException {
+        PortableVehicle vehicle = new PortableVehicle(13, "Vehicle");
         PortableLocation depot = visit(8, 42.6501218, -71.8835449, "Test depot");
         PortableLocation visit1 = visit(100, 42.7066596, -72.4934873, "Visit 1");
         PortableLocation visit2 = visit(200, 42.5543343, -71.4438280, "Visit 2");
 
         PortableRoute portableRoute = new PortableRoute(
+                vehicle,
                 depot,
                 asList(visit1, visit2),
                 asList(

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableVehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableVehicleTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.websocket;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.optaweb.vehiclerouting.domain.Vehicle;
+import org.springframework.boot.test.json.JacksonTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class PortableVehicleTest {
+
+    private JacksonTester<PortableVehicle> json;
+
+    @BeforeEach
+    void setUp() {
+        JacksonTester.initFields(this, new ObjectMapper());
+    }
+
+    @Test
+    void marshall_to_json() throws IOException {
+        long id = 321;
+        String name = "Pink: {XY-123} \"B\"";
+        PortableVehicle portableVehicle = new PortableVehicle(id, name);
+        assertThat(json.write(portableVehicle)).isEqualToJson(
+                String.format("{\"id\":%d,\"name\":\"%s\"}", id, name.replaceAll("\"", "\\\\\""))
+        );
+    }
+
+    @Test
+    void constructor_params_must_not_be_null() {
+        assertThatNullPointerException().isThrownBy(() -> new PortableVehicle(1, null));
+    }
+
+    @Test
+    void fromVehicle() {
+        long id = 321;
+        String name = "Pink XY-123 B";
+        PortableVehicle portableVehicle = PortableVehicle.fromVehicle(new Vehicle(id, name));
+        assertThat(portableVehicle.getId()).isEqualTo(id);
+        assertThat(portableVehicle.getName()).isEqualTo(name);
+
+        assertThatNullPointerException()
+                .isThrownBy(() -> PortableVehicle.fromVehicle(null))
+                .withMessageContaining("vehicle");
+    }
+
+    @Test
+    void equals_hashCode_toString() {
+        long id = 123456;
+        String name = "x y";
+        PortableVehicle portableVehicle = new PortableVehicle(id, name);
+
+        // equals()
+        assertThat(portableVehicle).isNotEqualTo(null);
+        assertThat(portableVehicle).isNotEqualTo(new Vehicle(id, name));
+        assertThat(portableVehicle).isNotEqualTo(new PortableVehicle(id + 1, name));
+        assertThat(portableVehicle).isNotEqualTo(new PortableVehicle(id, name + "z"));
+        assertThat(portableVehicle).isEqualTo(portableVehicle);
+        assertThat(portableVehicle).isEqualTo(new PortableVehicle(id, name));
+
+        // hasCode()
+        assertThat(portableVehicle).hasSameHashCodeAs(new PortableVehicle(id, name));
+
+        // toString()
+        assertThat(portableVehicle.toString()).contains(
+                String.valueOf(id),
+                name
+        );
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImplTest.java
@@ -30,6 +30,7 @@ import org.optaweb.vehiclerouting.domain.Location;
 import org.optaweb.vehiclerouting.domain.Route;
 import org.optaweb.vehiclerouting.domain.RouteWithTrack;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
+import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,12 +79,15 @@ class RoutePublisherImplTest {
         final Location location3 = new Location(3, coordinates3);
         final String distance = "xy";
 
+        final Vehicle vehicle1 = new Vehicle(1, "Vehicle 1");
+        final Vehicle vehicle2 = new Vehicle(2, "Vehicle 2");
+
         RouteWithTrack route1 = new RouteWithTrack(
-                new Route(location1, Collections.singletonList(location2)),
+                new Route(vehicle1, location1, Collections.singletonList(location2)),
                 Arrays.asList(segment12, segment21)
         );
         RouteWithTrack route2 = new RouteWithTrack(
-                new Route(location1, Collections.singletonList(location3)),
+                new Route(vehicle2, location1, Collections.singletonList(location3)),
                 Arrays.asList(segment13, segment31)
         );
 
@@ -96,6 +100,7 @@ class RoutePublisherImplTest {
 
         PortableRoute portableRoute1 = portableRoutingPlan.getRoutes().get(0);
 
+        assertThat(portableRoute1.getVehicle()).isEqualTo(PortableVehicle.fromVehicle(vehicle1));
         assertThat(portableRoute1.getDepot()).isEqualTo(PortableLocation.fromLocation(location1));
         assertThat(portableRoute1.getVisits()).containsExactly(
                 PortableLocation.fromLocation(location2)
@@ -114,6 +119,7 @@ class RoutePublisherImplTest {
 
         PortableRoute portableRoute2 = portableRoutingPlan.getRoutes().get(1);
 
+        assertThat(portableRoute2.getVehicle()).isEqualTo(PortableVehicle.fromVehicle(vehicle2));
         assertThat(portableRoute2.getDepot()).isEqualTo(PortableLocation.fromLocation(location1));
         assertThat(portableRoute2.getVisits()).containsExactly(
                 PortableLocation.fromLocation(location3)

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/RoutePublisherImplTest.java
@@ -16,8 +16,6 @@
 
 package org.optaweb.vehiclerouting.plugin.websocket;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -33,6 +31,8 @@ import org.optaweb.vehiclerouting.domain.RoutingPlan;
 import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -56,12 +56,14 @@ class RoutePublisherImplTest {
     void portable_routing_plan_empty() {
         PortableRoutingPlan portablePlan = RoutePublisherImpl.portable(RoutingPlan.empty());
         assertThat(portablePlan.getDistance()).isEmpty();
+        assertThat(portablePlan.getVehicles()).isEmpty();
         assertThat(portablePlan.getDepot()).isNull();
         assertThat(portablePlan.getRoutes()).isEmpty();
     }
 
     @Test
     void portable_routing_plan_with_two_routes() {
+        // arrange
         final Coordinates coordinates1 = Coordinates.valueOf(0.0, 0.1);
         final Coordinates coordinates2 = Coordinates.valueOf(2.0, -0.2);
         final Coordinates coordinates3 = Coordinates.valueOf(3.3, -3.3);
@@ -69,10 +71,10 @@ class RoutePublisherImplTest {
         final Coordinates checkpoint21 = Coordinates.valueOf(21, 21);
         final Coordinates checkpoint13 = Coordinates.valueOf(13, 13);
         final Coordinates checkpoint31 = Coordinates.valueOf(31, 31);
-        List<Coordinates> segment12 = Arrays.asList(coordinates1, checkpoint12, coordinates2);
-        List<Coordinates> segment21 = Arrays.asList(coordinates2, checkpoint21, coordinates1);
-        List<Coordinates> segment13 = Arrays.asList(coordinates1, checkpoint13, coordinates3);
-        List<Coordinates> segment31 = Arrays.asList(coordinates3, checkpoint31, coordinates1);
+        List<Coordinates> segment12 = asList(coordinates1, checkpoint12, coordinates2);
+        List<Coordinates> segment21 = asList(coordinates2, checkpoint21, coordinates1);
+        List<Coordinates> segment13 = asList(coordinates1, checkpoint13, coordinates3);
+        List<Coordinates> segment31 = asList(coordinates3, checkpoint31, coordinates1);
 
         final Location location1 = new Location(1, coordinates1);
         final Location location2 = new Location(2, coordinates2);
@@ -83,21 +85,35 @@ class RoutePublisherImplTest {
         final Vehicle vehicle2 = new Vehicle(2, "Vehicle 2");
 
         RouteWithTrack route1 = new RouteWithTrack(
-                new Route(vehicle1, location1, Collections.singletonList(location2)),
-                Arrays.asList(segment12, segment21)
+                new Route(vehicle1, location1, singletonList(location2)),
+                asList(segment12, segment21)
         );
         RouteWithTrack route2 = new RouteWithTrack(
-                new Route(vehicle2, location1, Collections.singletonList(location3)),
-                Arrays.asList(segment13, segment31)
+                new Route(vehicle2, location1, singletonList(location3)),
+                asList(segment13, segment31)
         );
 
-        RoutingPlan routingPlan = new RoutingPlan(distance, location1, Arrays.asList(route1, route2));
+        RoutingPlan routingPlan = new RoutingPlan(
+                distance,
+                asList(vehicle1, vehicle2),
+                location1,
+                asList(route1, route2)
+        );
 
+        // act
         PortableRoutingPlan portableRoutingPlan = RoutePublisherImpl.portable(routingPlan);
+
+        // assert
+        // -- plan
         assertThat(portableRoutingPlan.getDistance()).isEqualTo(distance);
         assertThat(portableRoutingPlan.getDepot()).isEqualTo(PortableLocation.fromLocation(location1));
         assertThat(portableRoutingPlan.getRoutes()).hasSize(2);
+        assertThat(portableRoutingPlan.getVehicles()).containsExactlyInAnyOrder(
+                PortableVehicle.fromVehicle(vehicle1),
+                PortableVehicle.fromVehicle(vehicle2)
+        );
 
+        // -- plan.route1
         PortableRoute portableRoute1 = portableRoutingPlan.getRoutes().get(0);
 
         assertThat(portableRoute1.getVehicle()).isEqualTo(PortableVehicle.fromVehicle(vehicle1));
@@ -117,6 +133,7 @@ class RoutePublisherImplTest {
                 PortableCoordinates.fromCoordinates(location1.coordinates())
         );
 
+        // -- plan.route2
         PortableRoute portableRoute2 = portableRoutingPlan.getRoutes().get(1);
 
         assertThat(portableRoute2.getVehicle()).isEqualTo(PortableVehicle.fromVehicle(vehicle2));

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
@@ -136,6 +136,12 @@ class WebSocketControllerTest {
     }
 
     @Test
+    void removeVehicle() {
+        webSocketController.removeVehicle(11L);
+        verify(vehicleService).removeVehicle(11);
+    }
+
+    @Test
     void demo() {
         String problemName = "xy";
         webSocketController.demo(problemName);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
@@ -27,17 +27,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
+import org.optaweb.vehiclerouting.domain.Route;
 import org.optaweb.vehiclerouting.domain.RouteWithTrack;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
 import org.optaweb.vehiclerouting.domain.RoutingProblem;
+import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.optaweb.vehiclerouting.service.demo.DemoService;
 import org.optaweb.vehiclerouting.service.location.LocationService;
 import org.optaweb.vehiclerouting.service.region.BoundingBox;
 import org.optaweb.vehiclerouting.service.region.RegionService;
 import org.optaweb.vehiclerouting.service.route.RouteListener;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +62,9 @@ class WebSocketControllerTest {
         // arrange
         String distance = "some distance";
         Location depot = new Location(1, Coordinates.valueOf(3, 5));
-        List<RouteWithTrack> routes = Collections.singletonList(mock(RouteWithTrack.class));
+        Vehicle vehicle = new Vehicle(1, "vehicle");
+        Route route = new Route(vehicle, depot, emptyList());
+        List<RouteWithTrack> routes = Collections.singletonList(new RouteWithTrack(route, emptyList()));
         RoutingPlan plan = new RoutingPlan(distance, depot, routes);
         when(routeListener.getBestRoutingPlan()).thenReturn(plan);
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
@@ -17,7 +17,6 @@
 package org.optaweb.vehiclerouting.plugin.websocket;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -40,6 +39,7 @@ import org.optaweb.vehiclerouting.service.route.RouteListener;
 import org.optaweb.vehiclerouting.service.vehicle.VehicleService;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,8 +67,8 @@ class WebSocketControllerTest {
         Location depot = new Location(1, Coordinates.valueOf(3, 5));
         Vehicle vehicle = new Vehicle(1, "vehicle");
         Route route = new Route(vehicle, depot, emptyList());
-        List<RouteWithTrack> routes = Collections.singletonList(new RouteWithTrack(route, emptyList()));
-        RoutingPlan plan = new RoutingPlan(distance, depot, routes);
+        List<RouteWithTrack> routes = singletonList(new RouteWithTrack(route, emptyList()));
+        RoutingPlan plan = new RoutingPlan(distance, singletonList(vehicle), depot, routes);
         when(routeListener.getBestRoutingPlan()).thenReturn(plan);
 
         // act
@@ -76,6 +76,7 @@ class WebSocketControllerTest {
 
         // assert
         assertThat(portableRoutingPlan.getDistance()).isEqualTo(distance);
+        assertThat(portableRoutingPlan.getVehicles()).containsExactly(PortableVehicle.fromVehicle(vehicle));
         assertThat(portableRoutingPlan.getDepot()).isEqualTo(PortableLocation.fromLocation(depot));
         assertThat(portableRoutingPlan.getRoutes()).hasSize(1);
     }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
@@ -37,6 +37,7 @@ import org.optaweb.vehiclerouting.service.location.LocationService;
 import org.optaweb.vehiclerouting.service.region.BoundingBox;
 import org.optaweb.vehiclerouting.service.region.RegionService;
 import org.optaweb.vehiclerouting.service.route.RouteListener;
+import org.optaweb.vehiclerouting.service.vehicle.VehicleService;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +51,8 @@ class WebSocketControllerTest {
     private RouteListener routeListener;
     @Mock
     private RegionService regionService;
+    @Mock
+    private VehicleService vehicleService;
     @Mock
     private LocationService locationService;
     @Mock
@@ -123,6 +126,12 @@ class WebSocketControllerTest {
     void removeLocation() {
         webSocketController.removeLocation(9L);
         verify(locationService).removeLocation(9);
+    }
+
+    @Test
+    void addVehicle() {
+        webSocketController.addVehicle();
+        verify(vehicleService).addVehicle();
     }
 
     @Test

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/DemoServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/DemoServiceTest.java
@@ -107,9 +107,7 @@ class DemoServiceTest {
 
         demoService.exportDataSet();
 
-        verify(dataSetMarshaller).marshal(routingProblemCaptor.capture());
-        RoutingProblem routingProblem = routingProblemCaptor.getValue();
-
+        RoutingProblem routingProblem = verifyAndCaptureMarshalledProblem();
         assertThat(routingProblem.name()).isNotNull();
         assertThat(routingProblem.depot()).contains(depot);
         assertThat(routingProblem.visits()).containsExactly(visit1, visit2);
@@ -121,11 +119,14 @@ class DemoServiceTest {
 
         demoService.exportDataSet();
 
-        verify(dataSetMarshaller).marshal(routingProblemCaptor.capture());
-        RoutingProblem routingProblem = routingProblemCaptor.getValue();
-
+        RoutingProblem routingProblem = verifyAndCaptureMarshalledProblem();
         assertThat(routingProblem.name()).isNotNull();
         assertThat(routingProblem.depot()).isEmpty();
         assertThat(routingProblem.visits()).isEmpty();
+    }
+
+    private RoutingProblem verifyAndCaptureMarshalledProblem() {
+        verify(dataSetMarshaller).marshal(routingProblemCaptor.capture());
+        return routingProblemCaptor.getValue();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
@@ -16,9 +16,6 @@
 
 package org.optaweb.vehiclerouting.service.location;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,14 +23,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -50,13 +43,8 @@ class LocationServiceTest {
     @InjectMocks
     private LocationService locationService;
 
-    @Mock
-    ApplicationStartedEvent event;
-
     private final Coordinates coordinates = Coordinates.valueOf(0.0, 1.0);
     private final Location location = new Location(1, coordinates);
-
-    private final List<Location> persistedLocations = Arrays.asList(location, location, location);
 
     @Test
     void createLocation_should_validate_arguments() {
@@ -73,7 +61,21 @@ class LocationServiceTest {
 
         verify(repository).createLocation(coordinates, description);
         verify(distanceMatrix).addLocation(location);
-        verify(optimizer).addLocation(eq(location), any(DistanceMatrix.class));
+        verify(optimizer).addLocation(location, distanceMatrix);
+    }
+
+    @Test
+    void addLocation_should_validate_arguments() {
+        assertThatNullPointerException().isThrownBy(() -> locationService.addLocation(null));
+    }
+
+    @Test
+    void addLocation() {
+        assertThat(locationService.addLocation(location)).isTrue();
+
+        verifyZeroInteractions(repository);
+        verify(distanceMatrix).addLocation(location);
+        verify(optimizer).addLocation(location, distanceMatrix);
     }
 
     @Test
@@ -96,20 +98,9 @@ class LocationServiceTest {
     }
 
     @Test
-    void should_reload_on_startup() {
-        when(repository.locations()).thenReturn(persistedLocations);
-
-        locationService.reload(event);
-
-        verify(repository).locations();
-        verify(distanceMatrix, times(persistedLocations.size())).addLocation(location);
-        verify(optimizer, times(persistedLocations.size())).addLocation(location, distanceMatrix);
-    }
-
-    @Test
     void should_not_optimize_and_roll_back_if_distance_calculation_fails() {
         when(repository.createLocation(coordinates, "")).thenReturn(location);
-        doThrow(RuntimeException.class).when(distanceMatrix).addLocation(any());
+        doThrow(RuntimeException.class).when(distanceMatrix).addLocation(location);
 
         assertThat(locationService.createLocation(coordinates, "")).isFalse();
         verifyZeroInteractions(optimizer);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/reload/ReloadServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/reload/ReloadServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.reload;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.optaweb.vehiclerouting.domain.Coordinates;
+import org.optaweb.vehiclerouting.domain.Location;
+import org.optaweb.vehiclerouting.service.location.LocationRepository;
+import org.optaweb.vehiclerouting.service.location.LocationService;
+import org.optaweb.vehiclerouting.service.vehicle.VehicleService;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReloadServiceTest {
+
+    @Mock
+    private VehicleService vehicleService;
+    @Mock
+    private LocationRepository locationRepository;
+    @Mock
+    private LocationService locationService;
+    @InjectMocks
+    private ReloadService reloadService;
+
+    @Mock
+    ApplicationStartedEvent event;
+
+    private final Coordinates coordinates = Coordinates.valueOf(0.0, 1.0);
+    private final Location location = new Location(1, coordinates);
+    private final List<Location> persistedLocations = Arrays.asList(location, location, location);
+
+    @Test
+    void should_reload_on_startup() {
+        when(locationRepository.locations()).thenReturn(persistedLocations);
+
+        reloadService.reload(event);
+
+        verify(vehicleService, atLeastOnce()).addVehicle();
+        verify(locationRepository).locations();
+        verify(locationService, times(persistedLocations.size())).addLocation(location);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
@@ -35,6 +35,7 @@ import org.optaweb.vehiclerouting.domain.RouteWithTrack;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
 import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.optaweb.vehiclerouting.service.location.LocationRepository;
+import org.optaweb.vehiclerouting.service.vehicle.VehicleRepository;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -53,6 +54,8 @@ class RouteListenerTest {
     private Router router;
     @Mock
     private RoutePublisher publisher;
+    @Mock
+    private VehicleRepository vehicleRepository;
     @Mock
     private LocationRepository locationRepository;
     @Captor
@@ -86,6 +89,7 @@ class RouteListenerTest {
         final Location depot = new Location(1, depotCoordinates);
         final Vehicle vehicle = new Vehicle(448, "Test vehicle");
         ShallowRoute route = new ShallowRoute(vehicle.id(), depot.id(), emptyList());
+        when(vehicleRepository.find(vehicle.id())).thenReturn(Optional.of(vehicle));
         when(locationRepository.find(depot.id())).thenReturn(Optional.of(depot));
 
         RouteChangedEvent event = new RouteChangedEvent(this, "0 km", depot.id(), singletonList(route));
@@ -119,6 +123,7 @@ class RouteListenerTest {
         final Location depot = new Location(1, depotCoordinates);
         final Location visit = new Location(2, visitCoordinates);
         final String distance = "xy";
+        when(vehicleRepository.find(vehicle.id())).thenReturn(Optional.of(vehicle));
         when(locationRepository.find(depot.id())).thenReturn(Optional.of(depot));
         when(locationRepository.find(visit.id())).thenReturn(Optional.of(visit));
 
@@ -143,9 +148,10 @@ class RouteListenerTest {
 
     @Test
     void should_discard_update_gracefully_if_one_of_location_has_been_removed() {
+        final Vehicle vehicle = new Vehicle(3, "x");
         final Location depot = new Location(1, Coordinates.valueOf(1.0, 2.0));
         final Location visit = new Location(2, Coordinates.valueOf(-1.0, -2.0));
-        final Vehicle vehicle = new Vehicle(3, "x");
+        when(vehicleRepository.find(vehicle.id())).thenReturn(Optional.of(vehicle));
         when(locationRepository.find(depot.id())).thenReturn(Optional.of(depot));
         when(locationRepository.find(visit.id())).thenReturn(Optional.empty());
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
@@ -184,7 +184,7 @@ class RouteListenerTest {
                 singletonList(route));
 
         // precondition
-        assertThat(routeListener.getBestRoutingPlan()).isEqualTo(RoutingPlan.empty());
+        assertThat(routeListener.getBestRoutingPlan().isEmpty()).isTrue();
 
         // must not throw exception
         routeListener.onApplicationEvent(event);
@@ -192,6 +192,6 @@ class RouteListenerTest {
         verify(router, never()).getPath(any(), any());
         verify(publisher, never()).publish(any());
 
-        assertThat(routeListener.getBestRoutingPlan()).isEqualTo(RoutingPlan.empty());
+        assertThat(routeListener.getBestRoutingPlan().isEmpty()).isTrue();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
@@ -79,9 +79,8 @@ class RouteListenerTest {
         RouteChangedEvent event = new RouteChangedEvent(this, "", singletonList(vehicleId), null, emptyList());
         routeListener.onApplicationEvent(event);
         verifyZeroInteractions(router);
-        verify(publisher).publish(routeArgumentCaptor.capture());
 
-        RoutingPlan routingPlan = routeArgumentCaptor.getValue();
+        RoutingPlan routingPlan = verifyAndCapturePublishedPlan();
         assertThat(routingPlan.vehicles()).containsExactly(vehicle);
         assertThat(routingPlan.depot()).isEmpty();
         assertThat(routingPlan.routes()).isEmpty();
@@ -107,9 +106,8 @@ class RouteListenerTest {
         routeListener.onApplicationEvent(event);
 
         verifyZeroInteractions(router);
-        verify(publisher).publish(routeArgumentCaptor.capture());
 
-        RoutingPlan routingPlan = routeArgumentCaptor.getValue();
+        RoutingPlan routingPlan = verifyAndCapturePublishedPlan();
         assertThat(routingPlan.vehicles()).containsExactly(vehicle);
         assertThat(routingPlan.depot()).contains(depot);
         assertThat(routingPlan.routes()).hasSize(1);
@@ -150,9 +148,8 @@ class RouteListenerTest {
         );
 
         routeListener.onApplicationEvent(event);
-        verify(publisher).publish(routeArgumentCaptor.capture());
 
-        RoutingPlan routingPlan = routeArgumentCaptor.getValue();
+        RoutingPlan routingPlan = verifyAndCapturePublishedPlan();
         assertThat(routingPlan.distance()).isEqualTo(distance);
         assertThat(routingPlan.vehicles()).containsExactly(vehicle);
         assertThat(routingPlan.depot()).contains(depot);
@@ -193,5 +190,10 @@ class RouteListenerTest {
         verify(publisher, never()).publish(any());
 
         assertThat(routeListener.getBestRoutingPlan().isEmpty()).isTrue();
+    }
+
+    private RoutingPlan verifyAndCapturePublishedPlan() {
+        verify(publisher).publish(routeArgumentCaptor.capture());
+        return routeArgumentCaptor.getValue();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/ShallowRouteTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/ShallowRouteTest.java
@@ -26,7 +26,7 @@ class ShallowRouteTest {
 
     @Test
     void shallow_route_to_string() {
-        ShallowRoute shallowRoute = new ShallowRoute(100L, Arrays.asList(93L, 92L, 91L));
-        assertThat(shallowRoute.toString()).containsSubsequence("100", "93", "92", "91");
+        ShallowRoute shallowRoute = new ShallowRoute(200L, 100L, Arrays.asList(93L, 92L, 91L));
+        assertThat(shallowRoute.toString()).containsSubsequence("200", "100", "93", "92", "91");
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/vehicle/VehicleServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/vehicle/VehicleServiceTest.java
@@ -47,4 +47,16 @@ class VehicleServiceTest {
 
         verify(optimizer).addVehicle(vehicle);
     }
+
+    @Test
+    void removeVehicle() {
+        final long vehicleId = 8;
+        final Vehicle vehicle = new Vehicle(vehicleId, "Removed vehicle");
+        when(vehicleRepository.removeVehicle(vehicleId)).thenReturn(vehicle);
+
+        vehicleService.removeVehicle(vehicleId);
+
+        verify(vehicleRepository).removeVehicle(vehicleId);
+        verify(optimizer).removeVehicle(vehicle);
+    }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/vehicle/VehicleServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/vehicle/VehicleServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.vehicle;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.optaweb.vehiclerouting.domain.Vehicle;
+import org.optaweb.vehiclerouting.service.location.RouteOptimizer;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VehicleServiceTest {
+
+    @Mock
+    private RouteOptimizer optimizer;
+    @Mock
+    private VehicleRepository vehicleRepository;
+    @InjectMocks
+    private VehicleService vehicleService;
+
+    @Test
+    void addVehicle() {
+        final Vehicle vehicle = new Vehicle(5, "Test vehicle");
+        when(vehicleRepository.createVehicle(anyString())).thenReturn(vehicle);
+
+        vehicleService.addVehicle();
+
+        verify(optimizer).addVehicle(vehicle);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/resources/org/optaweb/vehiclerouting/plugin/websocket/portable-route.json
+++ b/optaweb-vehicle-routing-backend/src/test/resources/org/optaweb/vehiclerouting/plugin/websocket/portable-route.json
@@ -1,4 +1,5 @@
 {
+  "vehicle": {"id": 13, "name": "Vehicle"},
   "depot": {"id": 8, "lat": 42.6501218, "lng": -71.8835449, "description": "Test depot"},
   "visits": [
     {"id": 100, "lat": 42.7066596, "lng": -72.4934873, "description": "Visit 1"},

--- a/optaweb-vehicle-routing-frontend/src/store/demo/demo.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/demo/demo.test.ts
@@ -78,6 +78,7 @@ const state: AppState = {
     distance: '10',
     depot: null,
     routes: [{
+      vehicle: { id: 1, name: 'v1' },
       visits: [{
         id: 1,
         lat: 1.345678,

--- a/optaweb-vehicle-routing-frontend/src/store/demo/demo.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/demo/demo.test.ts
@@ -63,6 +63,8 @@ describe('Demo reducers', () => {
   });
 });
 
+const vehicle1 = { id: 1, name: 'v1' };
+
 const state: AppState = {
   connectionStatus: WebSocketConnectionStatus.CLOSED,
   serverInfo: {
@@ -76,9 +78,10 @@ const state: AppState = {
   },
   plan: {
     distance: '10',
+    vehicles: [vehicle1],
     depot: null,
     routes: [{
-      vehicle: { id: 1, name: 'v1' },
+      vehicle: vehicle1,
       visits: [{
         id: 1,
         lat: 1.345678,

--- a/optaweb-vehicle-routing-frontend/src/store/route/actions.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/actions.ts
@@ -21,6 +21,7 @@ import {
   AddVehicleAction,
   ClearRouteAction,
   DeleteLocationAction,
+  DeleteVehicleAction,
   LatLngWithDescription,
   RoutingPlan,
   UpdateRouteAction,
@@ -28,6 +29,11 @@ import {
 
 export const addVehicle: ActionFactory<void, AddVehicleAction> = () => ({
   type: ActionType.ADD_VEHICLE,
+});
+
+export const deleteVehicle: ActionFactory<number, DeleteVehicleAction> = id => ({
+  type: ActionType.DELETE_VEHICLE,
+  value: id,
 });
 
 export const addLocation: ActionFactory<LatLngWithDescription, AddLocationAction> = location => ({

--- a/optaweb-vehicle-routing-frontend/src/store/route/actions.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/actions.ts
@@ -18,12 +18,17 @@ import { ActionFactory } from '../types';
 import {
   ActionType,
   AddLocationAction,
+  AddVehicleAction,
   ClearRouteAction,
   DeleteLocationAction,
   LatLngWithDescription,
   RoutingPlan,
   UpdateRouteAction,
 } from './types';
+
+export const addVehicle: ActionFactory<void, AddVehicleAction> = () => ({
+  type: ActionType.ADD_VEHICLE,
+});
 
 export const addLocation: ActionFactory<LatLngWithDescription, AddLocationAction> = location => ({
   type: ActionType.ADD_LOCATION,

--- a/optaweb-vehicle-routing-frontend/src/store/route/operations.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/operations.ts
@@ -21,6 +21,7 @@ import {
   AddVehicleAction,
   ClearRouteAction,
   DeleteLocationAction,
+  DeleteVehicleAction,
   LatLngWithDescription,
 } from './types';
 
@@ -42,6 +43,12 @@ export const addVehicle: ThunkCommandFactory<void, AddVehicleAction> = (
   () => (dispatch, getState, client) => {
     dispatch(actions.addVehicle());
     client.addVehicle();
+  });
+
+export const deleteVehicle: ThunkCommandFactory<number, DeleteVehicleAction> = (
+  vehicleId => (dispatch, getState, client) => {
+    dispatch(actions.deleteVehicle(vehicleId));
+    client.deleteVehicle(vehicleId);
   });
 
 export const clearRoute: ThunkCommandFactory<void, ClearRouteAction> = (

--- a/optaweb-vehicle-routing-frontend/src/store/route/operations.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/operations.ts
@@ -16,7 +16,13 @@
 
 import { ThunkCommandFactory } from '../types';
 import * as actions from './actions';
-import { AddLocationAction, ClearRouteAction, DeleteLocationAction, LatLngWithDescription } from './types';
+import {
+  AddLocationAction,
+  AddVehicleAction,
+  ClearRouteAction,
+  DeleteLocationAction,
+  LatLngWithDescription,
+} from './types';
 
 export const { updateRoute } = actions;
 
@@ -30,6 +36,12 @@ export const deleteLocation: ThunkCommandFactory<number, DeleteLocationAction> =
   locationId => (dispatch, getState, client) => {
     dispatch(actions.deleteLocation(locationId));
     client.deleteLocation(locationId);
+  });
+
+export const addVehicle: ThunkCommandFactory<void, AddVehicleAction> = (
+  () => (dispatch, getState, client) => {
+    dispatch(actions.addVehicle());
+    client.addVehicle();
   });
 
 export const clearRoute: ThunkCommandFactory<void, ClearRouteAction> = (

--- a/optaweb-vehicle-routing-frontend/src/store/route/reducers.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/reducers.ts
@@ -18,6 +18,7 @@ import { ActionType, RouteAction, RoutingPlan } from './types';
 
 export const initialRouteState: RoutingPlan = {
   distance: '0.00',
+  vehicles: [],
   depot: null,
   routes: [],
 };

--- a/optaweb-vehicle-routing-frontend/src/store/route/reducers.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/reducers.ts
@@ -17,7 +17,7 @@
 import { ActionType, RouteAction, RoutingPlan } from './types';
 
 export const initialRouteState: RoutingPlan = {
-  distance: '0.00',
+  distance: 'no data',
   vehicles: [],
   depot: null,
   routes: [],

--- a/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
@@ -105,14 +105,10 @@ describe('Route selectors', () => {
     expect(visits).toContain(state.plan.routes[1].visits[0]);
     expect(visits).toContain(state.plan.routes[1].visits[1]);
   });
-
-  it('getVehicles() should return each route\'s vehicle', () => {
-    const visits = routeSelectors.getVehicles(state.plan);
-    expect(visits).toHaveLength(2);
-    expect(visits).toContain(state.plan.routes[0].vehicle);
-    expect(visits).toContain(state.plan.routes[1].vehicle);
-  });
 });
+
+const vehicle1 = { id: 1, name: 'v1' };
+const vehicle2 = { id: 2, name: 'v2' };
 
 const state: AppState = {
   connectionStatus: WebSocketConnectionStatus.CLOSED,
@@ -127,9 +123,13 @@ const state: AppState = {
   },
   plan: {
     distance: '10',
+    vehicles: [
+      vehicle1,
+      vehicle2,
+    ],
     depot: null,
     routes: [{
-      vehicle: { id: 1, name: 'v1' },
+      vehicle: vehicle1,
       visits: [{
         id: 1,
         lat: 1.345678,
@@ -146,7 +146,7 @@ const state: AppState = {
 
       track: [[0.111222, 0.222333], [0.444555, 0.555666]],
     }, {
-      vehicle: { id: 2, name: 'v2' },
+      vehicle: vehicle2,
       visits: [{
         id: 4,
         lat: 4.345678,

--- a/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
@@ -86,7 +86,7 @@ describe('Route reducers', () => {
 });
 
 describe('Route selectors', () => {
-  it('visits should contain visits from all routes', () => {
+  it('getVisits() should return visits from all routes', () => {
     const visits = routeSelectors.getVisits(state.plan);
     expect(visits).toHaveLength(5);
     expect(visits).toContain(state.plan.routes[0].visits[0]);
@@ -94,6 +94,13 @@ describe('Route selectors', () => {
     expect(visits).toContain(state.plan.routes[0].visits[2]);
     expect(visits).toContain(state.plan.routes[1].visits[0]);
     expect(visits).toContain(state.plan.routes[1].visits[1]);
+  });
+
+  it('getVehicles() should return each route\'s vehicle', () => {
+    const visits = routeSelectors.getVehicles(state.plan);
+    expect(visits).toHaveLength(2);
+    expect(visits).toContain(state.plan.routes[0].vehicle);
+    expect(visits).toContain(state.plan.routes[1].vehicle);
   });
 });
 

--- a/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
@@ -112,6 +112,7 @@ const state: AppState = {
     distance: '10',
     depot: null,
     routes: [{
+      vehicle: { id: 1, name: 'v1' },
       visits: [{
         id: 1,
         lat: 1.345678,
@@ -128,6 +129,7 @@ const state: AppState = {
 
       track: [[0.111222, 0.222333], [0.444555, 0.555666]],
     }, {
+      vehicle: { id: 2, name: 'v2' },
       visits: [{
         id: 4,
         lat: 4.345678,

--- a/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
@@ -53,6 +53,16 @@ describe('Route operations', () => {
     expect(client.addLocation).toHaveBeenCalledTimes(1);
     expect(client.addLocation).toHaveBeenCalledWith(location);
   });
+
+  it('addVehicle() should call client', () => {
+    const { store, client } = mockStore(state);
+
+    store.dispatch(routeOperations.addVehicle());
+
+    expect(store.getActions()).toEqual([actions.addVehicle()]);
+    expect(client.addVehicle).toHaveBeenCalledTimes(1);
+    expect(client.addVehicle).toHaveBeenCalledWith();
+  });
 });
 
 describe('Route reducers', () => {

--- a/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
@@ -43,6 +43,17 @@ describe('Route operations', () => {
     expect(client.deleteLocation).toHaveBeenCalledWith(id);
   });
 
+  it('deleteVehicle() should call client', () => {
+    const { store, client } = mockStore(state);
+    const id = 5;
+
+    store.dispatch(routeOperations.deleteVehicle(id));
+
+    expect(store.getActions()).toEqual([actions.deleteVehicle(id)]);
+    expect(client.deleteVehicle).toHaveBeenCalledTimes(1);
+    expect(client.deleteVehicle).toHaveBeenCalledWith(id);
+  });
+
   it('addLocation() should call client', () => {
     const { store, client } = mockStore(state);
     const location: LatLngWithDescription = { lat: 11.01, lng: -35.79, description: 'new location' };
@@ -85,6 +96,18 @@ describe('Route reducers', () => {
   it('delete location', () => {
     expect(
       reducer(state.plan, actions.deleteLocation(1)),
+    ).toEqual(state.plan);
+  });
+
+  it('add vehicle', () => {
+    expect(
+      reducer(state.plan, actions.addVehicle()),
+    ).toEqual(state.plan);
+  });
+
+  it('delete vehicle', () => {
+    expect(
+      reducer(state.plan, actions.deleteVehicle(7)),
     ).toEqual(state.plan);
   });
 

--- a/optaweb-vehicle-routing-frontend/src/store/route/selectors.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/selectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Location, RoutingPlan } from './types';
+import { Location, RoutingPlan, Vehicle } from './types';
 
 function reducer<T>(accumulator: T[], currentValue: T[]): T[] {
   return accumulator.concat(currentValue);
@@ -26,4 +26,12 @@ export const getVisits = (plan: RoutingPlan): Location[] => {
   }
 
   return plan.routes.map(route => route.visits).reduce(reducer, []);
+};
+
+export const getVehicles = (plan: RoutingPlan): Vehicle[] => {
+  if (plan.routes.length === 0) {
+    return [];
+  }
+
+  return plan.routes.map(route => route.vehicle);
 };

--- a/optaweb-vehicle-routing-frontend/src/store/route/selectors.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/selectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Location, RoutingPlan, Vehicle } from './types';
+import { Location, RoutingPlan } from './types';
 
 function reducer<T>(accumulator: T[], currentValue: T[]): T[] {
   return accumulator.concat(currentValue);
@@ -26,12 +26,4 @@ export const getVisits = (plan: RoutingPlan): Location[] => {
   }
 
   return plan.routes.map(route => route.visits).reduce(reducer, []);
-};
-
-export const getVehicles = (plan: RoutingPlan): Vehicle[] => {
-  if (plan.routes.length === 0) {
-    return [];
-  }
-
-  return plan.routes.map(route => route.vehicle);
 };

--- a/optaweb-vehicle-routing-frontend/src/store/route/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/types.ts
@@ -60,6 +60,7 @@ export enum ActionType {
   DELETE_LOCATION = 'DELETE_LOCATION',
   ADD_LOCATION = 'ADD_LOCATION',
   ADD_VEHICLE = 'ADD_VEHICLE',
+  DELETE_VEHICLE = 'DELETE_VEHICLE',
   CLEAR_SOLUTION = 'CLEAR_SOLUTION',
 }
 
@@ -77,6 +78,10 @@ export interface DeleteLocationAction extends Action<ActionType.DELETE_LOCATION>
   readonly value: number;
 }
 
+export interface DeleteVehicleAction extends Action<ActionType.DELETE_VEHICLE> {
+  readonly value: number;
+}
+
 export interface UpdateRouteAction extends Action<ActionType.UPDATE_ROUTING_PLAN> {
   readonly plan: RoutingPlan;
 }
@@ -85,5 +90,6 @@ export type RouteAction =
   | AddLocationAction
   | AddVehicleAction
   | DeleteLocationAction
+  | DeleteVehicleAction
   | UpdateRouteAction
   | ClearRouteAction;

--- a/optaweb-vehicle-routing-frontend/src/store/route/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/types.ts
@@ -37,7 +37,7 @@ export interface Vehicle {
 }
 
 export interface Route {
-  readonly vehicle: Vehicle;
+  readonly vehicle: Vehicle; // TODO change to vehicleId
   readonly visits: Location[];
 }
 
@@ -49,6 +49,7 @@ export interface RouteWithTrack extends Route {
 
 export interface RoutingPlan {
   readonly distance: string;
+  readonly vehicles: Vehicle[];
   readonly depot: Location | null;
   // TODO visits: Location[];
   readonly routes: RouteWithTrack[];

--- a/optaweb-vehicle-routing-frontend/src/store/route/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/types.ts
@@ -58,11 +58,15 @@ export enum ActionType {
   UPDATE_ROUTING_PLAN = 'UPDATE_ROUTING_PLAN',
   DELETE_LOCATION = 'DELETE_LOCATION',
   ADD_LOCATION = 'ADD_LOCATION',
+  ADD_VEHICLE = 'ADD_VEHICLE',
   CLEAR_SOLUTION = 'CLEAR_SOLUTION',
 }
 
 export interface AddLocationAction extends Action<ActionType.ADD_LOCATION> {
   readonly value: LatLngWithDescription;
+}
+
+export interface AddVehicleAction extends Action<ActionType.ADD_VEHICLE> {
 }
 
 export interface ClearRouteAction extends Action<ActionType.CLEAR_SOLUTION> {
@@ -78,6 +82,7 @@ export interface UpdateRouteAction extends Action<ActionType.UPDATE_ROUTING_PLAN
 
 export type RouteAction =
   | AddLocationAction
+  | AddVehicleAction
   | DeleteLocationAction
   | UpdateRouteAction
   | ClearRouteAction;

--- a/optaweb-vehicle-routing-frontend/src/store/route/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/types.ts
@@ -31,7 +31,13 @@ export interface Location extends LatLng {
   readonly description?: string;
 }
 
+export interface Vehicle {
+  readonly id: number;
+  readonly name: string;
+}
+
 export interface Route {
+  readonly vehicle: Vehicle;
   readonly visits: Location[];
 }
 

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
@@ -216,19 +216,27 @@ describe('WebSocket reducers', () => {
 
 const emptyPlan: RoutingPlan = {
   distance: '',
+  vehicles: [],
   depot: null,
   routes: [],
 };
 
+const vehicle1 = { id: 1, name: 'v1' };
+const vehicle2 = { id: 2, name: 'v2' };
+
 const planWithTwoRoutes: RoutingPlan = {
   distance: '1.0',
+  vehicles: [
+    vehicle1,
+    vehicle2,
+  ],
   depot: {
     id: 1,
     lat: 1.345678,
     lng: 1.345678,
   },
   routes: [{
-    vehicle: { id: 1, name: 'v1' },
+    vehicle: vehicle1,
     visits: [{
       id: 2,
       lat: 2.345678,
@@ -240,7 +248,7 @@ const planWithTwoRoutes: RoutingPlan = {
     }],
     track: [],
   }, {
-    vehicle: { id: 2, name: 'v2' },
+    vehicle: vehicle2,
     visits: [{
       id: 4,
       lat: 1.345678,

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
@@ -228,6 +228,7 @@ const planWithTwoRoutes: RoutingPlan = {
     lng: 1.345678,
   },
   routes: [{
+    vehicle: { id: 1, name: 'v1' },
     visits: [{
       id: 2,
       lat: 2.345678,
@@ -239,6 +240,7 @@ const planWithTwoRoutes: RoutingPlan = {
     }],
     track: [],
   }, {
+    vehicle: { id: 2, name: 'v2' },
     visits: [{
       id: 4,
       lat: 1.345678,

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -29,7 +29,15 @@ exports[`App should render correctly 1`] = `
     >
       <Switch>
         <Route
-          component={[Function]}
+          component={
+            Object {
+              "$$typeof": Symbol(react.memo),
+              "WrappedComponent": [Function],
+              "compare": null,
+              "displayName": "Connect(Vehicles)",
+              "type": [Function],
+            }
+          }
           exact={true}
           path="/vehicles"
         />

--- a/optaweb-vehicle-routing-frontend/src/ui/components/LocationList.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/LocationList.tsx
@@ -28,7 +28,7 @@ export interface LocationListProps {
 }
 
 const renderEmptyLocationList: React.FC<LocationListProps> = () => (
-  <DataList aria-label="empty location list">
+  <DataList aria-label="Empty location list">
     <Bullseye>No locations</Bullseye>
   </DataList>
 );
@@ -41,7 +41,7 @@ const renderLocationList: React.FC<LocationListProps> = ({
 }) => (
   <div style={{ overflowY: 'auto' }}>
     <DataList
-      aria-label="simple-item1"
+      aria-label="List of locations"
     >
       {depot && (
         <LocationItem

--- a/optaweb-vehicle-routing-frontend/src/ui/components/TspMap.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/TspMap.tsx
@@ -19,12 +19,14 @@ import * as React from 'react';
 import { Map, Marker, Polyline, Rectangle, TileLayer, Tooltip, ZoomControl } from 'react-leaflet';
 import { LatLng, Location, RouteWithTrack } from 'store/route/types';
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
 export interface TspMapProps {
   selectedId: number;
   clickHandler: (e: React.SyntheticEvent<HTMLElement>) => void;
   removeHandler: (id: number) => void;
   depot: Location | null;
-  routes: RouteWithTrack[];
+  routes: Omit<RouteWithTrack, 'vehicle'>[];
   boundingBox: [LatLng, LatLng] | null;
 }
 

--- a/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/LocationList.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/LocationList.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Location List Component should render correctly with a few routes 1`] =
   }
 >
   <DataList
-    aria-label="simple-item1"
+    aria-label="List of locations"
     className=""
   >
     <Location
@@ -42,7 +42,7 @@ exports[`Location List Component should render correctly with a few routes 1`] =
 
 exports[`Location List Component should render correctly with no routes 1`] = `
 <DataList
-  aria-label="empty location list"
+  aria-label="Empty location list"
   className=""
 >
   <Bullseye

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.test.tsx
@@ -97,6 +97,7 @@ const threeLocationsProps: DemoProps = {
   }],
 
   routes: [{
+    vehicle: { id: 1, name: 'v1' },
     visits: [{
       id: 1,
       lat: 1.345678,

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Route.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Route.test.tsx
@@ -54,6 +54,7 @@ const twoRoutes: RouteProps = {
   },
 
   routes: [{
+    vehicle: { id: 1, name: 'v1' },
     visits: [{
       id: 1,
       lat: 1.345678,
@@ -71,6 +72,7 @@ const twoRoutes: RouteProps = {
     track: [],
 
   }, {
+    vehicle: { id: 2, name: 'v2' },
     visits: [{
       id: 1,
       lat: 1.345678,

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Route.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Route.tsx
@@ -117,13 +117,13 @@ export class Route extends React.Component<RouteProps, RouteState> {
                 aria-label="FormSelect Input"
               >
                 {routes.map(
-                  (option, index) => (
+                  (route, index) => (
                     <FormSelectOption
                       isDisabled={false}
                       // eslint-disable-next-line react/no-array-index-key
                       key={index}
                       value={index}
-                      label={`Route ${index}`}
+                      label={route.vehicle.name}
                     />
                   ),
                 )}

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
@@ -17,11 +17,12 @@
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import * as React from 'react';
-import { StateProps, Vehicles } from './Vehicles';
+import { Props, Vehicles } from './Vehicles';
 
 describe('Vehicles page', () => {
   it('should render correctly', () => {
-    const props: StateProps = {
+    const props: Props = {
+      addVehicleHandler: jest.fn(),
       vehicles: [
         { id: 1, name: 'Vehicle 1' },
         { id: 2, name: 'Vehicle 2' },

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
@@ -17,11 +17,17 @@
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import * as React from 'react';
-import Vehicles from './Vehicles';
+import { StateProps, Vehicles } from './Vehicles';
 
 describe('Vehicles page', () => {
   it('should render correctly', () => {
-    const vehicles = shallow(<Vehicles />);
+    const props: StateProps = {
+      vehicles: [
+        { id: 1, name: 'Vehicle 1' },
+        { id: 2, name: 'Vehicle 2' },
+      ],
+    };
+    const vehicles = shallow(<Vehicles {...props} />);
     expect(toJson(vehicles)).toMatchSnapshot();
   });
 });

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.test.tsx
@@ -23,6 +23,7 @@ describe('Vehicles page', () => {
   it('should render correctly', () => {
     const props: Props = {
       addVehicleHandler: jest.fn(),
+      removeVehicleHandler: jest.fn(),
       vehicles: [
         { id: 1, name: 'Vehicle 1' },
         { id: 2, name: 'Vehicle 2' },

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
@@ -14,9 +14,48 @@
  * limitations under the License.
  */
 
+import { DataList, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import * as React from 'react';
-import { UnderConstruction } from 'ui/components/UnderConstruction';
+import { connect } from 'react-redux';
+import { routeSelectors } from 'store/route';
+import { Vehicle } from 'store/route/types';
+import { AppState } from 'store/types';
+import LocationItem from 'ui/components/Location';
 
-const Vehicles = () => <UnderConstruction />;
+export interface StateProps {
+  vehicles: Vehicle[];
+}
 
-export default Vehicles;
+const mapStateToProps = ({ plan }: AppState): StateProps => ({
+  vehicles: routeSelectors.getVehicles(plan),
+});
+
+export const Vehicles: React.FC<StateProps> = ({ vehicles }) => (
+  <>
+    <TextContent>
+      <Text component={TextVariants.h1}>{`Vehicles (${vehicles.length})`}</Text>
+    </TextContent>
+    <div style={{ overflowY: 'auto' }}>
+      <DataList
+        aria-label="simple-item1"
+      >
+        {vehicles
+          .slice(0) // clone the array because
+          // sort is done in place (that would affect the route)
+          .sort((a, b) => a.id - b.id)
+          .map(vehicle => (
+            <LocationItem
+              key={vehicle.id}
+              id={vehicle.id}
+              description={vehicle.name}
+              removeDisabled={true}
+              removeHandler={() => null}
+              selectHandler={() => null}
+            />
+          ))}
+      </DataList>
+    </div>
+  </>
+);
+
+export default connect(mapStateToProps)(Vehicles);

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
@@ -14,27 +14,60 @@
  * limitations under the License.
  */
 
-import { DataList, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import {
+  Button,
+  DataList,
+  GutterSize,
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { routeSelectors } from 'store/route';
+import { routeOperations, routeSelectors } from 'store/route';
 import { Vehicle } from 'store/route/types';
 import { AppState } from 'store/types';
 import LocationItem from 'ui/components/Location';
 
-export interface StateProps {
+interface StateProps {
   vehicles: Vehicle[];
 }
+
+interface DispatchProps {
+  addVehicleHandler: typeof routeOperations.addVehicle;
+}
+
+export type Props = StateProps & DispatchProps;
 
 const mapStateToProps = ({ plan }: AppState): StateProps => ({
   vehicles: routeSelectors.getVehicles(plan),
 });
 
-export const Vehicles: React.FC<StateProps> = ({ vehicles }) => (
+const mapDispatchToProps: DispatchProps = {
+  addVehicleHandler: routeOperations.addVehicle,
+};
+
+export const Vehicles: React.FC<Props> = ({ vehicles, addVehicleHandler }) => (
   <>
-    <TextContent>
-      <Text component={TextVariants.h1}>{`Vehicles (${vehicles.length})`}</Text>
-    </TextContent>
+    <Split gutter={GutterSize.md} style={{ overflowY: 'auto' }}>
+      <SplitItem
+        isFilled={true}
+      >
+        <TextContent>
+          <Text component={TextVariants.h1}>{`Vehicles (${vehicles.length})`}</Text>
+        </TextContent>
+      </SplitItem>
+      <SplitItem isFilled={false}>
+        <Button
+          style={{ marginBottom: 16, marginLeft: 16 }}
+          onClick={addVehicleHandler}
+        >
+          Add
+        </Button>
+      </SplitItem>
+    </Split>
     <div style={{ overflowY: 'auto' }}>
       <DataList
         aria-label="List of vehicles"
@@ -58,4 +91,4 @@ export const Vehicles: React.FC<StateProps> = ({ vehicles }) => (
   </>
 );
 
-export default connect(mapStateToProps)(Vehicles);
+export default connect(mapStateToProps, mapDispatchToProps)(Vehicles);

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
@@ -26,7 +26,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { routeOperations, routeSelectors } from 'store/route';
+import { routeOperations } from 'store/route';
 import { Vehicle } from 'store/route/types';
 import { AppState } from 'store/types';
 import LocationItem from 'ui/components/Location';
@@ -42,7 +42,7 @@ interface DispatchProps {
 export type Props = StateProps & DispatchProps;
 
 const mapStateToProps = ({ plan }: AppState): StateProps => ({
-  vehicles: routeSelectors.getVehicles(plan),
+  vehicles: plan.vehicles,
 });
 
 const mapDispatchToProps: DispatchProps = {

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
@@ -37,6 +37,7 @@ interface StateProps {
 
 interface DispatchProps {
   addVehicleHandler: typeof routeOperations.addVehicle;
+  removeVehicleHandler: typeof routeOperations.deleteVehicle;
 }
 
 export type Props = StateProps & DispatchProps;
@@ -47,9 +48,10 @@ const mapStateToProps = ({ plan }: AppState): StateProps => ({
 
 const mapDispatchToProps: DispatchProps = {
   addVehicleHandler: routeOperations.addVehicle,
+  removeVehicleHandler: routeOperations.deleteVehicle,
 };
 
-export const Vehicles: React.FC<Props> = ({ vehicles, addVehicleHandler }) => (
+export const Vehicles: React.FC<Props> = ({ vehicles, addVehicleHandler, removeVehicleHandler }) => (
   <>
     <Split gutter={GutterSize.md} style={{ overflowY: 'auto' }}>
       <SplitItem
@@ -81,8 +83,8 @@ export const Vehicles: React.FC<Props> = ({ vehicles, addVehicleHandler }) => (
               key={vehicle.id}
               id={vehicle.id}
               description={vehicle.name}
-              removeDisabled={true}
-              removeHandler={() => null}
+              removeDisabled={false}
+              removeHandler={removeVehicleHandler}
               selectHandler={() => null}
             />
           ))}

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Vehicles.tsx
@@ -37,7 +37,7 @@ export const Vehicles: React.FC<StateProps> = ({ vehicles }) => (
     </TextContent>
     <div style={{ overflowY: 'auto' }}>
       <DataList
-        aria-label="simple-item1"
+        aria-label="List of vehicles"
       >
         {vehicles
           .slice(0) // clone the array because

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
@@ -181,6 +181,10 @@ exports[`Demo page clear and export buttons should be disabled when demo is load
         Array [
           Object {
             "track": Array [],
+            "vehicle": Object {
+              "id": 1,
+              "name": "v1",
+            },
             "visits": Array [
               Object {
                 "id": 1,
@@ -388,6 +392,10 @@ exports[`Demo page should render correctly with a few routes 1`] = `
         Array [
           Object {
             "track": Array [],
+            "vehicle": Object {
+              "id": 1,
+              "name": "v1",
+            },
             "visits": Array [
               Object {
                 "id": 1,

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Route.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Route.test.tsx.snap
@@ -45,14 +45,14 @@ exports[`Route page should render correctly with a few routes 1`] = `
             className=""
             isDisabled={false}
             key="0"
-            label="Route 0"
+            label="v1"
             value={0}
           />
           <FormSelectOption
             className=""
             isDisabled={false}
             key="1"
-            label="Route 1"
+            label="v2"
             value={1}
           />
         </FormSelect>
@@ -107,6 +107,10 @@ exports[`Route page should render correctly with a few routes 1`] = `
           Array [
             Object {
               "track": Array [],
+              "vehicle": Object {
+                "id": 1,
+                "name": "v1",
+              },
               "visits": Array [
                 Object {
                   "id": 1,

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
@@ -56,16 +56,16 @@ exports[`Vehicles page should render correctly 1`] = `
         description="Vehicle 1"
         id={1}
         key="1"
-        removeDisabled={true}
-        removeHandler={[Function]}
+        removeDisabled={false}
+        removeHandler={[MockFunction]}
         selectHandler={[Function]}
       />
       <Location
         description="Vehicle 2"
         id={2}
         key="2"
-        removeDisabled={true}
-        removeHandler={[Function]}
+        removeDisabled={false}
+        removeHandler={[MockFunction]}
         selectHandler={[Function]}
       />
     </DataList>

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
@@ -2,13 +2,45 @@
 
 exports[`Vehicles page should render correctly 1`] = `
 <Fragment>
-  <TextContent>
-    <Text
-      component="h1"
+  <Split
+    className=""
+    component="div"
+    gutter="md"
+    style={
+      Object {
+        "overflowY": "auto",
+      }
+    }
+  >
+    <SplitItem
+      className=""
+      isFilled={true}
     >
-      Vehicles (2)
-    </Text>
-  </TextContent>
+      <TextContent>
+        <Text
+          component="h1"
+        >
+          Vehicles (2)
+        </Text>
+      </TextContent>
+    </SplitItem>
+    <SplitItem
+      className=""
+      isFilled={false}
+    >
+      <Button
+        onClick={[MockFunction]}
+        style={
+          Object {
+            "marginBottom": 16,
+            "marginLeft": 16,
+          }
+        }
+      >
+        Add
+      </Button>
+    </SplitItem>
+  </Split>
   <div
     style={
       Object {

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
@@ -1,3 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Vehicles page should render correctly 1`] = `<UnderConstruction />`;
+exports[`Vehicles page should render correctly 1`] = `
+<Fragment>
+  <TextContent>
+    <Text
+      component="h1"
+    >
+      Vehicles (2)
+    </Text>
+  </TextContent>
+  <div
+    style={
+      Object {
+        "overflowY": "auto",
+      }
+    }
+  >
+    <DataList
+      aria-label="simple-item1"
+      className=""
+    >
+      <Location
+        description="Vehicle 1"
+        id={1}
+        key="1"
+        removeDisabled={true}
+        removeHandler={[Function]}
+        selectHandler={[Function]}
+      />
+      <Location
+        description="Vehicle 2"
+        id={2}
+        key="2"
+        removeDisabled={true}
+        removeHandler={[Function]}
+        selectHandler={[Function]}
+      />
+    </DataList>
+  </div>
+</Fragment>
+`;

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Vehicles.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Vehicles page should render correctly 1`] = `
     }
   >
     <DataList
-      aria-label="simple-item1"
+      aria-label="List of vehicles"
       className=""
     >
       <Location

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
@@ -96,6 +96,15 @@ describe('WebSocketClient', () => {
     expect(mockClient.send).toHaveBeenCalledWith('/app/vehicle');
   });
 
+  it('deleteVehicle() should send vehicle ID', () => {
+    const vehicleId = 34;
+
+    client.connect(onSuccess, onError);
+    client.deleteVehicle(vehicleId);
+
+    expect(mockClient.send).toHaveBeenCalledWith(`/app/vehicle/${vehicleId}/delete`, JSON.stringify(vehicleId));
+  });
+
   it('loadDemo() should send demo name', () => {
     const demo = 'Test demo';
 

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
@@ -89,6 +89,13 @@ describe('WebSocketClient', () => {
     expect(mockClient.send).toHaveBeenCalledWith(`/app/location/${locationId}/delete`, JSON.stringify(locationId));
   });
 
+  it('addVehicle() should add vehicle', () => {
+    client.connect(onSuccess, onError);
+    client.addVehicle();
+
+    expect(mockClient.send).toHaveBeenCalledWith('/app/vehicle');
+  });
+
   it('loadDemo() should send demo name', () => {
     const demo = 'Test demo';
 

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
@@ -72,6 +72,12 @@ export default class WebSocketClient {
     }
   }
 
+  deleteVehicle(vehicleId: number) {
+    if (this.stompClient) {
+      this.stompClient.send(`/app/vehicle/${vehicleId}/delete`, JSON.stringify(vehicleId));
+    }
+  }
+
   clear() {
     if (this.stompClient) {
       this.stompClient.send('/app/clear');

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
@@ -54,6 +54,12 @@ export default class WebSocketClient {
     }
   }
 
+  addVehicle() {
+    if (this.stompClient) {
+      this.stompClient.send('/app/vehicle');
+    }
+  }
+
   loadDemo(name: string): void {
     if (this.stompClient) {
       this.stompClient.send(`/app/demo/${name}`);


### PR DESCRIPTION
## Basic vehicles support
- Six vehicles generated on startup.
- Existing vehicles are displayed on the Vehicles page.
- Vehicles can be added and removed.
- It's possible to add vehicles even when there are no visits and no depot.
- It's *not possible* to add visits (only the depot) when there are no vehicles. This is corner case that will cause the backend to crash. Addressing it will require a substantial refactoring of `RouteOptimizerImpl` and will be delivered in a following PR.

## Remaining tasks (future PRs)
- Persist vehicles to DB.
- Export/import from YAML data sets.
- Clear button should not remove vehicles.
- Show vehicle count on Demo page.
- UX: remember center & zoom level - restore when switching between screens.
- Add "Add vehicle" button to Demo page.