### PR TITLE
Upgrade to latest H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   </modules>
 
   <properties>
+    <version.com.h2database>1.4.199</version.com.h2database>
     <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.org.assertj>3.11.1</version.org.assertj>
     <version.org.mockito>2.23.4</version.org.mockito>


### PR DESCRIPTION
1.4.199 is what we had before inheriting kie-parent, which uses an outdated
version 1.3.173.

Another reason why I want prevent users from experiencing the upgrade
from 1.3.x to 1.4.x is that the DB file name has changed
(vrp.h2.db -> vrp.mv.db). We would need to document this in release
notes.