### PR TITLE
BXMSPROD-495 distribution not excluded from assembly

### DIFF
--- a/optaweb-vehicle-routing-distribution/src/main/assembly/assembly-optaweb-vehicle-routing.xml
+++ b/optaweb-vehicle-routing-distribution/src/main/assembly/assembly-optaweb-vehicle-routing.xml
@@ -41,7 +41,6 @@
         <exclude>**/.vscode/**</exclude>
         <exclude>**/.DS_Store</exclude>
         <exclude>.git/**</exclude>
-        <exclude>optaweb-vehicle-routing-distribution/**</exclude>
         <exclude>optaweb-vehicle-routing-frontend/node_modules/**</exclude>
         <exclude>optaweb-vehicle-routing-frontend/.scannerwork/**</exclude>
         <exclude>optaweb-vehicle-routing-frontend/coverage/**</exclude>


### PR DESCRIPTION
@yurloc I finally had to add distribution folder to the sources folder, otherwise the source code from distribution assembly file won't compile.