### PR TITLE
Add sanity check script for the distribution assembly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,9 @@ script:
   # check that git working tree is clean after running npm install via a frontend-maven-plugin
   # the git command returns 1 and fails the build if there are any uncommitted changes
   - git diff HEAD --exit-code
+  # Sanity-check distribution assembly
+  - >
+    cd optaweb-vehicle-routing-distribution/target
+    && unzip -q *.zip
+    && cd optaweb-vehicle-routing-distribution-*/sources
+    && mvn validate


### PR DESCRIPTION
Add Travis script that will fail the build if distribution isn't assembled correctly (it only runs `mvn validate` in it).