### PR TITLE
Update Node.js to latest LTS

### DIFF
--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -63,7 +63,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v8.12.0</nodeVersion>
+              <nodeVersion>v10.16.3</nodeVersion>
               <npmVersion>6.9.0</npmVersion>
             </configuration>
           </execution>


### PR DESCRIPTION
From nodejs.org [download](https://nodejs.org/en/download/) site:

Latest LTS Version: 10.16.3 (includes npm 6.9.0)