### PR TITLE
Do not deploy build artifacts to Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,13 @@
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${version.org.springframework.boot}</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
         <!--
           Disable Jacoco check inherited from kie-parent. Remove this when it's removed from kie-parent
           (but some projects still use the check fail build).


### PR DESCRIPTION
When I inherited `kie-parent` and plugged this repository into kiegroup build, I didn't realize that all build artifacts will get deployed to JBoss Nexus. I think it is an unnecessary pollution of the Maven repository as none of the artifacts are intended to be depended on by other projects.

@mareknovotny Can you point me to a project that consumes the distribution ZIP if there is one? If not let's skip deploy plugin completely in this repo.