### PR TITLE
Remove unnecessary properties

### DIFF
--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -31,13 +31,6 @@
   <name>OptaWeb Vehicle Routing Frontend</name>
 
   <properties>
-    <!--
-      Intentionally leaving these properties empty so that the Frontend plugin uses default values and downloads
-      Node.js and npm from https://nodejs.org/dist/. Having these properties here makes it possible to change the URLs
-      using system properties. This is necessary for CI builds running on Red Hat infrastructure.
-    -->
-    <nodeDownloadRoot/>
-    <npmDownloadRoot/>
     <sonar.sources>src</sonar.sources>
     <sonar.test.inclusions>
       optaweb-vehicle-routing-frontend/**/*test.ts,optaweb-vehicle-routing-frontend/**/*test.tsx
@@ -72,8 +65,6 @@
             <configuration>
               <nodeVersion>v11.6.0</nodeVersion>
               <npmVersion>6.9.0</npmVersion>
-              <nodeDownloadRoot>${nodeDownloadRoot}</nodeDownloadRoot>
-              <npmDownloadRoot>${npmDownloadRoot}</npmDownloadRoot>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
The Frontend Maven plugin's configuration properties can already be
overridden using System properties without any extra POM modifications.

Tested locally. Cleaned up the downloaded and unpacked binaries first:
- `rm -r node/`
- `rm -r ~/.m2/repository/com/github/eirslett/{node,npm}`

This forces Frontend plugin to re-download binaries:

```
[INFO] --- frontend-maven-plugin:1.7.5:install-node-and-npm (install node and npm) @ optaweb-vehicle-routing-frontend ---
[INFO] Installing node version v11.6.0
[INFO] Downloading http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/rhba/dist/node/v11.6.0/node-v11.6.0-linux-x64.tar.gz to /home/jlocker/.m2/repository/com/github/eirslett/node/11.6.0/node-11.6.0-linux-x64.tar.gz
[INFO] No proxies configured
[INFO] No proxy was configured, downloading directly
[INFO] Unpacking /home/jlocker/.m2/repository/com/github/eirslett/node/11.6.0/node-11.6.0-linux-x64.tar.gz into /home/jlocker/src/github.com/kiegroup/optaweb-vehicle-routing/optaweb-vehicle-routing-frontend/node/tmp
[INFO] Copying node binary from /home/jlocker/src/github.com/kiegroup/optaweb-vehicle-routing/optaweb-vehicle-routing-frontend/node/tmp/node-v11.6.0-linux-x64/bin/node to /home/jlocker/src/github.com/kiegroup/optaweb-vehicle-routing/optaweb-vehicle-routing-frontend/node/node
[INFO] Installed node locally.
[INFO] Installing npm version 6.9.0
[INFO] Downloading http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/rhba/dist/npm/npm-6.9.0.tgz to /home/jlocker/.m2/repository/com/github/eirslett/npm/6.9.0/npm-6.9.0.tar.gz
[INFO] No proxies configured
[INFO] No proxy was configured, downloading directly
[INFO] Unpacking /home/jlocker/.m2/repository/com/github/eirslett/npm/6.9.0/npm-6.9.0.tar.gz into /home/jlocker/src/github.com/kiegroup/optaweb-vehicle-routing/optaweb-vehicle-routing-frontend/node/node_modules
[INFO] Installed npm locally.
```

My `~/.m2/settings.xml`:

```xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
  <profiles>
    <profile>
      <id>frontend-maven-plugin-config</id>
      <properties>
        <yarnDownloadRoot>http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/rhba/dist/yarn/</yarnDownloadRoot>
        <nodeDownloadRoot>http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/rhba/dist/node/</nodeDownloadRoot>
        <npmDownloadRoot>http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/rhba/dist/npm/</npmDownloadRoot>
      </properties>
    </profile>
  </profiles>
  <activeProfiles>
    <activeProfile>frontend-maven-plugin-config</activeProfile>
  </activeProfiles>
</settings>
```