### PR TITLE
Run lint in compile phase to fail Maven build on Jenkins

### DIFF
--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -93,7 +93,7 @@
           </execution>
           <execution>
             <id>npm run lint</id>
-            <phase>test</phase>
+            <phase>compile</phase>
             <goals>
               <goal>npm</goal>
             </goals>


### PR DESCRIPTION
Jenkins uses `-Dmaven.test.failure.ignore` to run the complete build
even if some tests are failing. Frontend plugin honors this property
in such a way that any goal ran in the test phase doesn't fail
the build (even if it returns non-zero code) but we want typecheck
and lint to fail the build.

Frontend plugin issue with related information: https://github.com/eirslett/frontend-maven-plugin/issues/534.