### PR TITLE
Don't use default excludes in distribution assembly to keep .gitignores

### DIFF
--- a/optaweb-vehicle-routing-distribution/src/main/assembly/assembly-optaweb-vehicle-routing.xml
+++ b/optaweb-vehicle-routing-distribution/src/main/assembly/assembly-optaweb-vehicle-routing.xml
@@ -27,6 +27,7 @@
 
   <fileSets>
     <fileSet><!-- Note: going outside the module dir is bad, but it is not fetching generated files -->
+      <useDefaultExcludes>false</useDefaultExcludes>
       <directory>..</directory>
       <outputDirectory>sources</outputDirectory>
       <excludes>


### PR DESCRIPTION
Gitignores are imporant part of the source code. They provide
information about which files are not intended to be committed to the
SCM. This could be useful if user initializes a Git repository in the
source distribution.