### PR TITLE
Make http://backend:8080 default BACKEND_URL in frontend Dockerfile

### DIFF
--- a/optaweb-vehicle-routing-frontend/docker/Dockerfile
+++ b/optaweb-vehicle-routing-frontend/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/library/nginx:1.17.5
 COPY nginx.conf /etc/nginx
 COPY default.conf /tmp/default.template
-ARG BACKEND_URL
+ARG BACKEND_URL=http://backend:8080
 RUN envsubst '${BACKEND_URL}' < /tmp/default.template > /etc/nginx/conf.d/default.conf \
         && rm /tmp/default.template \
 # Make directories used by nginx owned and writable by the root group to support arbitrary user ID.

--- a/provision.sh
+++ b/provision.sh
@@ -180,7 +180,7 @@ oc set volumes dc/backend --add \
 
 # Frontend
 # -- binary build
-oc new-build --name frontend --strategy=docker --binary -e BACKEND_URL=http://backend:8080
+oc new-build --name frontend --strategy=docker --binary
 oc start-build frontend --from-dir=${dir_frontend}/docker --follow
 # -- new app
 oc new-app frontend


### PR DESCRIPTION
OpenShift Online complains about a build with docker strategy for the
frontend. However backend build with the same strategy is OK. The only
difference is that frontend build defines an environment variable with
backend URL. The attempt to create the build failed with:

    error: failed to set env: admission webhook "validate.build.create" denied
       the request: Builds with docker strategy are prohibited on this cluster

Removing the enviroment variable makes the build work (even thought it
still uses the docker strategy ¯\\_(ツ)_/¯). Might be an OpenShift bug.

The same error as above is produced by:

    oc set env bc/frontend BACKEND_URL=http://backend:8080

so maybe it's just that docker builds can't have environment variables.