### PR TITLE
Place all frontend test reports in a single subdirectory

### DIFF
--- a/optaweb-vehicle-routing-frontend/cypress.json
+++ b/optaweb-vehicle-routing-frontend/cypress.json
@@ -3,6 +3,7 @@
     "chromeWebSecurity": false,
     "reporter": "junit",
     "reporterOptions": {
-          "mochaFile": "target/test-reports/TEST-cypress.xml"
+          "mochaFile": "target/test-reports/TEST-cypress.xml",
+          "jenkinsMode": true
     }
 }

--- a/optaweb-vehicle-routing-frontend/cypress.json
+++ b/optaweb-vehicle-routing-frontend/cypress.json
@@ -3,6 +3,6 @@
     "chromeWebSecurity": false,
     "reporter": "junit",
     "reporterOptions": {
-          "mochaFile": "target/TEST-cypress.xml"
+          "mochaFile": "target/test-reports/TEST-cypress.xml"
     }
 }

--- a/optaweb-vehicle-routing-frontend/package.json
+++ b/optaweb-vehicle-routing-frontend/package.json
@@ -37,7 +37,7 @@
     "cypress:run": "cypress run"
   },
   "jest-junit": {
-    "outputDirectory": "./target/surefire-reports",
+    "outputDirectory": "./target/test-reports",
     "outputName": "TEST-frontend.xml",
     "suiteName": "org.optaweb.vehiclerouting.frontend.tests",
     "suiteNameTemplate": "{filepath}",


### PR DESCRIPTION
Jenkins jobs expect test results to be stored in
**/target/*-reports/TEST-*.xml