### PR TITLE
Avoid unnecessary plugin management

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -127,90 +127,36 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <compilerArgs>
-              <!--
-                Visit https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html
-                to learn more about javac warnings
-               -->
-              <arg>-Xlint:all</arg>
-              <arg>-Xlint:-processing</arg>
-              <arg>-Xlint:-serial</arg>
-            </compilerArgs>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.pitest</groupId>
-          <artifactId>pitest-maven</artifactId>
-          <version>1.4.3</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.pitest</groupId>
-              <artifactId>pitest-junit5-plugin</artifactId>
-              <version>0.8</version>
-            </dependency>
-          </dependencies>
-          <!--
-            kie-parent contains Pitest configuration that doesn't work well for this project and it's not possible
-            to change it without a complete override (combine.self="override"), for example excludedClasses,
-            timeoutConstant.
-          -->
-          <configuration combine.self="override">
-            <reportsDirectory>local/pit-reports</reportsDirectory>
-            <timestampedReports>true</timestampedReports>
-            <!--
-              Experimental. Using more than 2 threads doesn't reduce execution time further
-              and leads to minion timeouts.
-            -->
-            <threads>2</threads>
-            <mutators>
-              <!-- See http://pitest.org/quickstart/mutators/ -->
-              <mutator>DEFAULTS</mutator>
-              <mutator>NON_VOID_METHOD_CALLS</mutator>
-              <mutator>REMOVE_CONDITIONALS</mutator>
-            </mutators>
-            <avoidCallsTo>
-              <!--
-                String concatenation ("a" + "b") is implemented using StringBuilder.append() in bytecode.
-                We're not interested in mutations of these calls - it's mostly toString() and exception messages.
-                Reducing number of mutations also improves execution time.
-              -->
-              <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
-              <avoidCallsTo>org.slf4j</avoidCallsTo>
-              <avoidCallsTo>org.springframework.boot.SpringApplication</avoidCallsTo>
-            </avoidCallsTo>
-            <excludedClasses>
-              <excludedClass>*Config</excludedClass>
-              <excludedClass>*Properties</excludedClass>
-            </excludedClasses>
-            <excludedMethods>hashCode</excludedMethods>
-            <excludedTestClasses>
-              <param>*IntegrationTest</param>
-            </excludedTestClasses>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <configuration>
-            <!--
-              Required due to the "repackage" goal of spring-boot-maven-plugin, as the maven-failsafe-plugin cannot
-              find classes in the fat jar. For more details see:
-              https://sandor-nemeth.github.io/2017/10/16/integration-tests-with-spring-boot-classnotfoundexception.html
-            -->
-            <additionalClasspathElements>
-              <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
-            </additionalClasspathElements>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <!--
+              Visit https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html
+              to learn more about javac warnings
+             -->
+            <arg>-Xlint:all</arg>
+            <arg>-Xlint:-processing</arg>
+            <arg>-Xlint:-serial</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <!--
+            Required due to the "repackage" goal of spring-boot-maven-plugin, as the maven-failsafe-plugin cannot
+            find classes in the fat jar. For more details see:
+            https://sandor-nemeth.github.io/2017/10/16/integration-tests-with-spring-boot-classnotfoundexception.html
+          -->
+          <additionalClasspathElements>
+            <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -271,6 +217,52 @@
           <plugin>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-maven</artifactId>
+            <version>1.4.3</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-junit5-plugin</artifactId>
+                <version>0.8</version>
+              </dependency>
+            </dependencies>
+            <!--
+              kie-parent contains Pitest configuration that doesn't work well for this project and it's not possible
+              to change it without a complete override (combine.self="override"), for example excludedClasses,
+              timeoutConstant.
+            -->
+            <configuration combine.self="override">
+              <reportsDirectory>local/pit-reports</reportsDirectory>
+              <timestampedReports>true</timestampedReports>
+              <!--
+                Experimental. Using more than 2 threads doesn't reduce execution time further
+                and leads to minion timeouts.
+              -->
+              <threads>2</threads>
+              <mutators>
+                <!-- See http://pitest.org/quickstart/mutators/ -->
+                <mutator>DEFAULTS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS</mutator>
+              </mutators>
+              <avoidCallsTo>
+                <!--
+                  String concatenation ("a" + "b") is implemented using StringBuilder.append() in bytecode.
+                  We're not interested in mutations of these calls - it's mostly toString() and exception messages.
+                  Reducing number of mutations also improves execution time.
+                -->
+                <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
+                <avoidCallsTo>org.slf4j</avoidCallsTo>
+                <avoidCallsTo>org.springframework.boot.SpringApplication</avoidCallsTo>
+              </avoidCallsTo>
+              <excludedClasses>
+                <excludedClass>*Config</excludedClass>
+                <excludedClass>*Properties</excludedClass>
+              </excludedClasses>
+              <excludedMethods>hashCode</excludedMethods>
+              <excludedTestClasses>
+                <param>*IntegrationTest</param>
+              </excludedTestClasses>
+            </configuration>
             <executions>
               <execution>
                 <id>default-pitest</id>

--- a/optaweb-vehicle-routing-docs/pom.xml
+++ b/optaweb-vehicle-routing-docs/pom.xml
@@ -40,91 +40,78 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
+        <configuration>
+          <imagesDir>.</imagesDir>
+          <attributes>
+            <revnumber>${project.version}</revnumber>
+          </attributes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-single-html</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+            <configuration>
+              <!-- Needs to be duplicated to avoid rendering each adoc separately -->
+              <sourceDocumentName>${source.document.name}</sourceDocumentName>
+              <backend>html5</backend>
+              <sourceHighlighter>highlightjs</sourceHighlighter>
+              <outputDirectory>${project.build.directory}/generated-docs/html_single</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-pdf</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+            <configuration>
+              <!-- Needs to be duplicated to avoid rendering each adoc separately -->
+              <sourceDocumentName>${source.document.name}</sourceDocumentName>
+              <backend>pdf</backend>
+              <sourceHighlighter>coderay</sourceHighlighter><!-- highlightjs does not work in PDF -->
+              <outputDirectory>${project.build.directory}/generated-docs/pdf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>1.5.5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj-pdf</artifactId>
+            <version>1.5.0-alpha.15</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package-generated-docs</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly-generated-docs-zip.xml</descriptor>
+              </descriptors>
+              <archive>
+                <addMavenDescriptor>true</addMavenDescriptor>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.asciidoctor</groupId>
-          <artifactId>asciidoctor-maven-plugin</artifactId>
-          <configuration>
-            <imagesDir>.</imagesDir>
-            <attributes>
-              <revnumber>${project.version}</revnumber>
-            </attributes>
-          </configuration>
-          <executions>
-            <execution>
-              <id>generate-single-html</id>
-              <phase>generate-resources</phase>
-              <goals>
-                <goal>process-asciidoc</goal>
-              </goals>
-              <configuration>
-                <!-- Needs to be duplicated to avoid rendering each adoc separately -->
-                <sourceDocumentName>${source.document.name}</sourceDocumentName>
-                <backend>html5</backend>
-                <sourceHighlighter>highlightjs</sourceHighlighter>
-                <outputDirectory>${project.build.directory}/generated-docs/html_single</outputDirectory>
-              </configuration>
-            </execution>
-            <execution>
-              <id>generate-pdf</id>
-              <phase>generate-resources</phase>
-              <goals>
-                <goal>process-asciidoc</goal>
-              </goals>
-              <configuration>
-                <!-- Needs to be duplicated to avoid rendering each adoc separately -->
-                <sourceDocumentName>${source.document.name}</sourceDocumentName>
-                <backend>pdf</backend>
-                <sourceHighlighter>coderay</sourceHighlighter><!-- highlightjs does not work in PDF -->
-                <outputDirectory>${project.build.directory}/generated-docs/pdf</outputDirectory>
-              </configuration>
-            </execution>
-          </executions>
-          <dependencies>
-            <dependency>
-              <groupId>org.asciidoctor</groupId>
-              <artifactId>asciidoctorj</artifactId>
-              <version>1.5.5</version>
-            </dependency>
-            <dependency>
-              <groupId>org.asciidoctor</groupId>
-              <artifactId>asciidoctorj-pdf</artifactId>
-              <version>1.5.0-alpha.15</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>package-generated-docs</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
-              <configuration>
-                <finalName>${project.artifactId}-${project.version}</finalName>
-                <appendAssemblyId>false</appendAssemblyId>
-                <descriptors>
-                  <descriptor>src/main/assembly/assembly-generated-docs-zip.xml</descriptor>
-                </descriptors>
-                <archive>
-                  <addMavenDescriptor>true</addMavenDescriptor>
-                </archive>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 </project>

--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -33,17 +33,15 @@
 
   <properties>
     <application.port>8180</application.port>
-    <backend.project.name>optaweb-vehicle-routing-backend</backend.project.name>
-    <backend.osm.file>planet_12.032,53.0171_12.1024,53.0491.osm.pbf</backend.osm.file>
-    <frontend.project.name>optaweb-vehicle-routing-frontend</frontend.project.name>
-    <version.cypress.docker>3.6.0</version.cypress.docker>
-    <skipTests>false</skipTests>
     <!-- Override to run with Podman -->
     <container.runtime>docker</container.runtime>
+    <frontend.project.name>optaweb-vehicle-routing-frontend</frontend.project.name>
+    <test.osm.file>planet_12.032,53.0171_12.1024,53.0491.osm.pbf</test.osm.file>
+    <version.cypress.docker>3.6.0</version.cypress.docker>
   </properties>
 
   <dependencies>
-    <!-- Just to make sure this module builds after backend and frontend. -->
+    <!-- Only to make sure this module is built after backend and frontend. -->
     <dependency>
       <groupId>org.optaweb.vehiclerouting</groupId>
       <artifactId>optaweb-vehicle-routing-backend</artifactId>
@@ -145,9 +143,6 @@
               <groupId>com.bazaarvoice.maven.plugins</groupId>
               <artifactId>process-exec-maven-plugin</artifactId>
               <version>0.9</version>
-              <configuration>
-                <skip>${skipTests}</skip>
-              </configuration>
             </plugin>
           </plugins>
         </pluginManagement>
@@ -193,7 +188,7 @@
                     <argument>--app.region.country-codes=DE</argument>
                     <argument>--app.routing.gh-dir=target/graphhopper</argument>
                     <argument>--app.routing.osm-dir=data/openstreetmap</argument>
-                    <argument>--app.routing.osm-file=${backend.osm.file}</argument>
+                    <argument>--app.routing.osm-file=${test.osm.file}</argument>
                   </arguments>
                 </configuration>
               </execution>
@@ -222,7 +217,6 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <skip>${skipTests}</skip>
                   <executable>${container.runtime}</executable>
                   <workingDirectory>${project.parent.basedir}/${frontend.project.name}</workingDirectory>
                   <arguments>

--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -137,15 +137,6 @@
         </property>
       </activation>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>com.bazaarvoice.maven.plugins</groupId>
-              <artifactId>process-exec-maven-plugin</artifactId>
-              <version>0.9</version>
-            </plugin>
-          </plugins>
-        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>org.soulwing</groupId>
@@ -165,6 +156,7 @@
           <plugin> <!-- Start standalone JAR as a separate process -->
             <groupId>com.bazaarvoice.maven.plugins</groupId>
             <artifactId>process-exec-maven-plugin</artifactId>
+            <version>0.9</version>
             <executions>
               <execution>
                 <id>start-application</id>


### PR DESCRIPTION
https://maven.apache.org/pom.html#Plugin_Management

It makes no sense to use `<pluginManagement/>` in a leaf POM. By removing unnecessary plugin management we achieve less code and better coherence.