### PR TITLE
PLANNER-1813: Use UBI-based image for backend

### DIFF
--- a/optaweb-vehicle-routing-backend/Dockerfile
+++ b/optaweb-vehicle-routing-backend/Dockerfile
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fabric8/java-alpine-openjdk8-jre:1.6.3
+FROM adoptopenjdk/openjdk8:ubi-minimal-jre
 ENV APP_ROUTING_ENGINE air
-COPY target/*-exec.jar /deployments
+COPY target/*-exec.jar /opt/app/optaweb-vehicle-routing.jar
+WORKDIR /opt/app
+VOLUME /opt/app/local
+CMD ["java", "-jar", "optaweb-vehicle-routing.jar"]
 EXPOSE 8080
-VOLUME /deployments/local


### PR DESCRIPTION
Fixes the problem with downloading OSM file from an HTTPS URL. Tested locally with CRC.