### PR TITLE
PLANNER-1782: Upgrade AsciidoctorJ and Asciidoctor Maven Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 git:
   depth: false
 language: java
-jdk: openjdk8
+jdk:
+  - openjdk8
+  - openjdk11
 cache:
   directories:
     - "$HOME/.m2/repository"

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -82,6 +82,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <!--
+      Add JAXB API dependency that's been deprecated in Java 9 and dropped in Java 11. See
+      https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
+    -->
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!-- Testing dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/optaweb-vehicle-routing-docs/pom.xml
+++ b/optaweb-vehicle-routing-docs/pom.xml
@@ -40,6 +40,7 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>2.0.0-RC.1</version>
         <configuration>
           <imagesDir>.</imagesDir>
           <attributes>
@@ -80,12 +81,12 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.5</version>
+            <version>2.2.0</version>
           </dependency>
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
-            <version>1.5.0-alpha.15</version>
+            <version>1.5.0-beta.8</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
This fixes a problem when building on OpenJDK 11.

See also
- https://github.com/asciidoctor/asciidoctorj/issues/515.
- https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j

After 7.33.0 release, I'll upgrade the plugin in kie-parent and remove overrides in all repositories: https://issues.redhat.com/browse/PLANNER-1839.