### PR TITLE
Do not hardcode production profile in the backend Dockerfile

### DIFF
--- a/optaweb-vehicle-routing-backend/Dockerfile
+++ b/optaweb-vehicle-routing-backend/Dockerfile
@@ -17,5 +17,5 @@ ENV APP_ROUTING_ENGINE air
 COPY target/*-exec.jar /opt/app/optaweb-vehicle-routing.jar
 WORKDIR /opt/app
 VOLUME /opt/app/local
-CMD ["java", "-jar", "optaweb-vehicle-routing.jar", "--spring.profiles.active=production"]
+CMD ["java", "-jar", "optaweb-vehicle-routing.jar"]
 EXPOSE 8080

--- a/runOnOpenShift.sh
+++ b/runOnOpenShift.sh
@@ -67,6 +67,7 @@ function wrong_args() {
 
 # Process arguments
 declare -a dc_backend_env
+dc_backend_env+=("SPRING_PROFILES_ACTIVE=production")
 case $# in
   0)
     print_help
@@ -181,6 +182,7 @@ oc start-build backend --from-dir=${dir_backend} --follow
 oc new-app backend
 # -- use PostgreSQL secret
 oc set env dc/backend --from=secret/postgresql
+# -- set the rest of the configuration
 oc set env dc/backend "${dc_backend_env[@]}"
 # Remove the default emptyDir volume
 oc set volumes dc/backend --remove --name backend-volume-1


### PR DESCRIPTION
The `--spring.profiles.active` argument would prevent profile activation
using environment variables.

Aligns VR with ER (https://github.com/kiegroup/optaweb-employee-rostering/pull/379).