### PR TITLE
Remove obsolete javax.validation version override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <!-- Define JaCoCo agent argLine property to avoid Surefire failure when JaCoCo is not enabled. -->
     <jacoco.agent.argLine/>
     <version.com.h2database>1.4.199</version.com.h2database>
-    <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.org.mockito>3.1.0</version.org.mockito>
     <version.org.postgresql>42.2.5</version.org.postgresql>
   </properties>


### PR DESCRIPTION
javax.validation is no longer in the dependency tree.