### PR TITLE
Remove jackson-databind override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,6 @@
       </dependency>
       <!-- Dependencies not managed by kie-parent and version overrides -->
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.9.10</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>2.9.10</version>


### PR DESCRIPTION
This artifacts is already managed by kie-parent where it receives Dependabot updates. No longer needs overriding.