### PR TITLE
BXMSPROD-741: Remove Node and npm versions

### DIFF
--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -35,10 +35,6 @@
     <sonar.sources>src</sonar.sources>
     <sonar.test.inclusions>**/*test.ts,**/*test.tsx</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths>coverage/lcov.info</sonar.javascript.lcov.reportPaths>
-
-    <!-- Frontend properties -->
-    <node.version>v11.6.0</node.version>
-    <npm.version>6.9.0</npm.version>
   </properties>
 
   <build>
@@ -54,10 +50,6 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <configuration>
-              <nodeVersion>${node.version}</nodeVersion>
-              <npmVersion>${npm.version}</npmVersion>
-            </configuration>
           </execution>
           <execution>
             <id>npm install lock-treatment-tool and run-node</id>


### PR DESCRIPTION
They are now managed by kie-parent.

PR group:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1273
- https://github.com/kiegroup/appformer/pull/943
- https://github.com/kiegroup/droolsjbpm-integration/pull/2064
- https://github.com/kiegroup/kie-wb-common/pull/3269
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/296
- https://github.com/kiegroup/optaweb-employee-rostering/pull/425