### PR TITLE
Remove deprecated API usage after Spring upgrade

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -322,6 +322,14 @@
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!-- Append jacoco.agent.argLine property populated by JaCoCo's prepare-agent goal. -->
+              <argLine>@{jacoco.agent.argLine}</argLine>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/DataSetDownloadController.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/DataSetDownloadController.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.ZonedDateTime;
 
 import org.optaweb.vehiclerouting.service.demo.DemoService;
 import org.springframework.core.io.InputStreamResource;
@@ -54,8 +53,6 @@ class DataSetDownloadController {
             HttpHeaders headers = new HttpHeaders();
             ContentDisposition attachment = ContentDisposition.builder("attachment")
                     .filename("vrp_data_set.yaml")
-                    .creationDate(ZonedDateTime.now())
-                    .size((long) dataSetBytes.length)
                     .build();
             headers.setContentDisposition(attachment);
             return ResponseEntity.ok()

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/DataSetDownloadControllerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/DataSetDownloadControllerTest.java
@@ -58,10 +58,9 @@ class DataSetDownloadControllerTest {
         assertThat(headers.getContentType().toString()).isEqualToIgnoringWhitespace("text/x-yaml;charset=UTF-8");
         assertThat(headers.getContentDisposition()).isNotNull();
         String contentDisposition = headers.getContentDisposition().toString();
-        assertThat(contentDisposition).startsWith("attachment;");
-        assertThat(contentDisposition).containsPattern("; *filename=\".*\\.yaml\";");
-        assertThat(contentDisposition).contains("size=" + msg.length());
-        assertThat(contentDisposition).contains("creation-date=");
+        assertThat(contentDisposition)
+                .startsWith("attachment;")
+                .containsPattern("; *filename=\".*\\.yaml\"");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -132,14 +132,6 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- Append jacoco.agent.argLine property populated by JaCoCo's prepare-agent goal. -->
-            <argLine>@{jacoco.agent.argLine}</argLine>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Spring Framework and Spring Boot were upgraded to 5.2.5 and 2.2.6 in https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1297.

Removing deprecated API usage in response to the upgrade.

Also moving Surefire configuration with `@{jacoco.agent.argLine}` to a profile to make it possible to run tests from IDEA. @rsynek I recently noticed this works in `optaplanner` repo. Not sure if there has been any fix on IntelliJ side.