### PR TITLE
PLANNER-1995: Use a database file per region when using run script

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application.properties
@@ -32,7 +32,7 @@ logging.level.org.optaweb.vehiclerouting=info
 # Datasource
 # - using an embedded DB with relative path: http://h2database.com/html/features.html#embedded_databases
 # - not closing the DB automatically: http://h2database.com/html/features.html#closing_a_database
-spring.datasource.url=jdbc:h2:file:${app.persistence.h2-dir:./local/db}/vrp;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
+spring.datasource.url=jdbc:h2:file:${app.persistence.h2-dir:./local/db}/${app.persistence.h2-filename:vrp};DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update

--- a/runLocally.sh
+++ b/runLocally.sh
@@ -91,6 +91,7 @@ function validate() {
 function run_optaweb() {
   declare -a args
   args+=("--app.persistence.h2-dir=$vrp_dir/db")
+  args+=("--app.persistence.h2-filename=${osm_file%.osm.pbf}")
   args+=("--app.routing.engine=$routing_engine")
   if [[ ${routing_engine} == "graphhopper" ]]
   then


### PR DESCRIPTION
The DB file name still defaults to `vrp` but it can be configured using `app.persistence.h2-filename` property. The run script sets the property to the region name so that each region has a dedicated db file. That is convenient when switching between different regions.

Example:
You can start with Belgium, load cities data set, shut down without cleaning the database and switch to France. The app will now start successfully because it will no longer try to load Belgian cities created in the previous run.