### PR TITLE
PLANNER-1897: Make Demo the landing page

### DIFF
--- a/optaweb-vehicle-routing-frontend/cypress/integration/fromLocationsToRoute.js
+++ b/optaweb-vehicle-routing-frontend/cypress/integration/fromLocationsToRoute.js
@@ -55,7 +55,7 @@ describe('Locations can be added and route is computed', () => {
     });
 
     cy.get('[data-cy=demo-add-vehicle]').click();
-    cy.get('a[href="/route"]').click();
+    cy.get('a[href="/routes"]').click();
     cy.get('[data-cy=location-list]').find('li').should((list) => {
       cities.forEach((city) => expect(list).to.contain(city));
     });

--- a/optaweb-vehicle-routing-frontend/package.json
+++ b/optaweb-vehicle-routing-frontend/package.json
@@ -30,6 +30,7 @@
     "test": "react-scripts test --reporters=default --reporters=jest-junit",
     "eject": "react-scripts eject",
     "coverage": "npm run test -- --coverage --watchAll=false",
+    "update-snapshots": "npm run test -- -u --watchAll=false",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --ext .js,.ts,.tsx src/ cypress/",
     "lint:fix": "npm run lint -- --fix",

--- a/optaweb-vehicle-routing-frontend/src/ui/App.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/App.tsx
@@ -52,6 +52,11 @@ const App: React.FC = () => (
               component={page}
             />
           ))}
+          <Route
+            path="/"
+            exact
+            component={Demo}
+          />
         </Switch>
       </PageSection>
     </Page>

--- a/optaweb-vehicle-routing-frontend/src/ui/App.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/App.tsx
@@ -26,7 +26,7 @@ import { Demo, Route as RoutePage, Vehicles, Visits } from './pages';
 export const pagesByPath = [
   { path: '/vehicles', page: Vehicles, label: 'Vehicles' },
   { path: '/visits', page: Visits, label: 'Visits' },
-  { path: '/route', page: RoutePage, label: 'Route' },
+  { path: '/routes', page: RoutePage, label: 'Routes' },
   { path: '/demo', page: Demo, label: 'Demo' },
 ];
 

--- a/optaweb-vehicle-routing-frontend/src/ui/App.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/App.tsx
@@ -24,10 +24,10 @@ import Header from './header/Header';
 import { Demo, Route as RoutePage, Vehicles, Visits } from './pages';
 
 export const pagesByPath = [
+  { path: '/demo', page: Demo, label: 'Demo' },
   { path: '/vehicles', page: Vehicles, label: 'Vehicles' },
   { path: '/visits', page: Visits, label: 'Visits' },
   { path: '/routes', page: RoutePage, label: 'Routes' },
-  { path: '/demo', page: Demo, label: 'Demo' },
 ];
 
 const App: React.FC = () => (

--- a/optaweb-vehicle-routing-frontend/src/ui/App.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/App.tsx
@@ -23,6 +23,13 @@ import { ConnectionManager } from './connection';
 import Header from './header/Header';
 import { Demo, Route as RoutePage, Vehicles, Visits } from './pages';
 
+export const pagesByPath = [
+  { path: '/vehicles', page: Vehicles, label: 'Vehicles' },
+  { path: '/visits', page: Visits, label: 'Visits' },
+  { path: '/route', page: RoutePage, label: 'Route' },
+  { path: '/demo', page: Demo, label: 'Demo' },
+];
+
 const App: React.FC = () => (
   <>
     <ConnectionManager />
@@ -37,26 +44,14 @@ const App: React.FC = () => (
         }}
       >
         <Switch>
-          <Route
-            path="/vehicles"
-            exact
-            component={Vehicles}
-          />
-          <Route
-            path="/visits"
-            exact
-            component={Visits}
-          />
-          <Route
-            path="/route"
-            exact
-            component={RoutePage}
-          />
-          <Route
-            path="/demo"
-            exact
-            component={Demo}
-          />
+          {pagesByPath.map(({ path, page }) => (
+            <Route
+              key={path}
+              path={path}
+              exact
+              component={page}
+            />
+          ))}
         </Switch>
       </PageSection>
     </Page>

--- a/optaweb-vehicle-routing-frontend/src/ui/App.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/App.tsx
@@ -24,10 +24,10 @@ import Header from './header/Header';
 import { Demo, Route as RoutePage, Vehicles, Visits } from './pages';
 
 export const pagesByPath = [
-  { path: '/demo', page: Demo, label: 'Demo' },
-  { path: '/vehicles', page: Vehicles, label: 'Vehicles' },
-  { path: '/visits', page: Visits, label: 'Visits' },
-  { path: '/routes', page: RoutePage, label: 'Routes' },
+  { path: { canonical: '/demo', aliases: ['/'] }, page: Demo, label: 'Demo' },
+  { path: { canonical: '/vehicles', aliases: [] }, page: Vehicles, label: 'Vehicles' },
+  { path: { canonical: '/visits', aliases: [] }, page: Visits, label: 'Visits' },
+  { path: { canonical: '/routes', aliases: [] }, page: RoutePage, label: 'Routes' },
 ];
 
 const App: React.FC = () => (
@@ -44,19 +44,14 @@ const App: React.FC = () => (
         }}
       >
         <Switch>
-          {pagesByPath.map(({ path, page }) => (
+          {pagesByPath.map(({ path, page }) => ([path.canonical, ...path.aliases].map((p) => (
             <Route
-              key={path}
-              path={path}
+              key={p}
+              path={p}
               exact
               component={page}
             />
-          ))}
-          <Route
-            path="/"
-            exact
-            component={Demo}
-          />
+          ))))}
         </Switch>
       </PageSection>
     </Page>

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -46,6 +46,20 @@ exports[`App should render correctly 1`] = `
               "$$typeof": Symbol(react.memo),
               "WrappedComponent": [Function],
               "compare": null,
+              "displayName": "Connect(Demo)",
+              "type": [Function],
+            }
+          }
+          exact={true}
+          key="/"
+          path="/"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.memo),
+              "WrappedComponent": [Function],
+              "compare": null,
               "displayName": "Connect(Vehicles)",
               "type": [Function],
             }
@@ -81,19 +95,6 @@ exports[`App should render correctly 1`] = `
           exact={true}
           key="/routes"
           path="/routes"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "displayName": "Connect(Demo)",
-              "type": [Function],
-            }
-          }
-          exact={true}
-          path="/"
         />
       </Switch>
     </PageSection>

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -65,8 +65,8 @@ exports[`App should render correctly 1`] = `
             }
           }
           exact={true}
-          key="/route"
-          path="/route"
+          key="/routes"
+          path="/routes"
         />
         <Route
           component={

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -32,6 +32,20 @@ exports[`App should render correctly 1`] = `
               "$$typeof": Symbol(react.memo),
               "WrappedComponent": [Function],
               "compare": null,
+              "displayName": "Connect(Demo)",
+              "type": [Function],
+            }
+          }
+          exact={true}
+          key="/demo"
+          path="/demo"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.memo),
+              "WrappedComponent": [Function],
+              "compare": null,
               "displayName": "Connect(Vehicles)",
               "type": [Function],
             }
@@ -67,20 +81,6 @@ exports[`App should render correctly 1`] = `
           exact={true}
           key="/routes"
           path="/routes"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "displayName": "Connect(Demo)",
-              "type": [Function],
-            }
-          }
-          exact={true}
-          key="/demo"
-          path="/demo"
         />
       </Switch>
     </PageSection>

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -82,6 +82,19 @@ exports[`App should render correctly 1`] = `
           key="/routes"
           path="/routes"
         />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.memo),
+              "WrappedComponent": [Function],
+              "compare": null,
+              "displayName": "Connect(Demo)",
+              "type": [Function],
+            }
+          }
+          exact={true}
+          path="/"
+        />
       </Switch>
     </PageSection>
   </Page>

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`App should render correctly 1`] = `
             }
           }
           exact={true}
+          key="/vehicles"
           path="/vehicles"
         />
         <Route
@@ -50,6 +51,7 @@ exports[`App should render correctly 1`] = `
             }
           }
           exact={true}
+          key="/visits"
           path="/visits"
         />
         <Route
@@ -63,6 +65,7 @@ exports[`App should render correctly 1`] = `
             }
           }
           exact={true}
+          key="/route"
           path="/route"
         />
         <Route
@@ -76,6 +79,7 @@ exports[`App should render correctly 1`] = `
             }
           }
           exact={true}
+          key="/demo"
           path="/demo"
         />
       </Switch>

--- a/optaweb-vehicle-routing-frontend/src/ui/header/Navigation.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/header/Navigation.test.tsx
@@ -30,16 +30,18 @@ describe('Navigation', () => {
       } as Location<unknown>,
     } as RouteComponentProps;
 
+    const visitsId = '/visits';
+
     const navigation = shallow(<Navigation {...props} />);
     expect(toJson(navigation)).toMatchSnapshot();
 
     // NavItem matching the path should be active
-    const navItems = navigation.find(NavItem).filterWhere((navItem) => navItem.props().itemId === 'visits');
+    const navItems = navigation.find(NavItem).filterWhere((navItem) => navItem.props().itemId === visitsId);
     expect(navItems).toHaveLength(1);
     expect(navItems.at(0).props().isActive).toEqual(true);
 
     // Other NavItems should be inactive
-    navigation.find(NavItem).filterWhere((navItem) => navItem.props().itemId !== 'visits').forEach(
+    navigation.find(NavItem).filterWhere((navItem) => navItem.props().itemId !== visitsId).forEach(
       (navItem) => expect(navItem.props().isActive).toEqual(false),
     );
   });

--- a/optaweb-vehicle-routing-frontend/src/ui/header/Navigation.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/header/Navigation.tsx
@@ -18,23 +18,20 @@ import { Nav, NavItem, NavList, NavVariants } from '@patternfly/react-core';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { Link, withRouter } from 'react-router-dom';
+import { pagesByPath } from 'ui/App';
 
 export const Navigation = ({ location }: RouteComponentProps) => (
   <Nav aria-label="Nav">
     <NavList variant={NavVariants.horizontal}>
-      {['Vehicles', 'Visits', 'Route', 'Demo'].map((label) => {
-        const itemId = label.toLowerCase();
-        const path = `/${itemId}`;
-        return (
-          <NavItem
-            key={itemId}
-            itemId={itemId}
-            isActive={location.pathname === path}
-          >
-            <Link to={path}>{label}</Link>
-          </NavItem>
-        );
-      })}
+      {pagesByPath.map(({ path, label }) => (
+        <NavItem
+          key={path}
+          itemId={path}
+          isActive={location.pathname === path}
+        >
+          <Link to={path}>{label}</Link>
+        </NavItem>
+      ))}
     </NavList>
   </Nav>
 );

--- a/optaweb-vehicle-routing-frontend/src/ui/header/Navigation.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/header/Navigation.tsx
@@ -25,11 +25,11 @@ export const Navigation = ({ location }: RouteComponentProps) => (
     <NavList variant={NavVariants.horizontal}>
       {pagesByPath.map(({ path, label }) => (
         <NavItem
-          key={path}
-          itemId={path}
-          isActive={location.pathname === path}
+          key={path.canonical}
+          itemId={path.canonical}
+          isActive={[...path.aliases, path.canonical].includes(location.pathname)}
         >
-          <Link to={path}>{label}</Link>
+          <Link to={path.canonical}>{label}</Link>
         </NavItem>
       ))}
     </NavList>

--- a/optaweb-vehicle-routing-frontend/src/ui/header/__snapshots__/Navigation.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/header/__snapshots__/Navigation.test.tsx.snap
@@ -12,8 +12,8 @@ exports[`Navigation should activate a navigation link matching the current path 
   >
     <NavItem
       isActive={false}
-      itemId="vehicles"
-      key="vehicles"
+      itemId="/vehicles"
+      key="/vehicles"
     >
       <Link
         to="/vehicles"
@@ -23,8 +23,8 @@ exports[`Navigation should activate a navigation link matching the current path 
     </NavItem>
     <NavItem
       isActive={true}
-      itemId="visits"
-      key="visits"
+      itemId="/visits"
+      key="/visits"
     >
       <Link
         to="/visits"
@@ -34,8 +34,8 @@ exports[`Navigation should activate a navigation link matching the current path 
     </NavItem>
     <NavItem
       isActive={false}
-      itemId="route"
-      key="route"
+      itemId="/route"
+      key="/route"
     >
       <Link
         to="/route"
@@ -45,8 +45,8 @@ exports[`Navigation should activate a navigation link matching the current path 
     </NavItem>
     <NavItem
       isActive={false}
-      itemId="demo"
-      key="demo"
+      itemId="/demo"
+      key="/demo"
     >
       <Link
         to="/demo"

--- a/optaweb-vehicle-routing-frontend/src/ui/header/__snapshots__/Navigation.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/header/__snapshots__/Navigation.test.tsx.snap
@@ -12,6 +12,17 @@ exports[`Navigation should activate a navigation link matching the current path 
   >
     <NavItem
       isActive={false}
+      itemId="/demo"
+      key="/demo"
+    >
+      <Link
+        to="/demo"
+      >
+        Demo
+      </Link>
+    </NavItem>
+    <NavItem
+      isActive={false}
       itemId="/vehicles"
       key="/vehicles"
     >
@@ -41,17 +52,6 @@ exports[`Navigation should activate a navigation link matching the current path 
         to="/routes"
       >
         Routes
-      </Link>
-    </NavItem>
-    <NavItem
-      isActive={false}
-      itemId="/demo"
-      key="/demo"
-    >
-      <Link
-        to="/demo"
-      >
-        Demo
       </Link>
     </NavItem>
   </NavList>

--- a/optaweb-vehicle-routing-frontend/src/ui/header/__snapshots__/Navigation.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/header/__snapshots__/Navigation.test.tsx.snap
@@ -34,13 +34,13 @@ exports[`Navigation should activate a navigation link matching the current path 
     </NavItem>
     <NavItem
       isActive={false}
-      itemId="/route"
-      key="/route"
+      itemId="/routes"
+      key="/routes"
     >
       <Link
-        to="/route"
+        to="/routes"
       >
-        Route
+        Routes
       </Link>
     </NavItem>
     <NavItem

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
@@ -43,6 +43,7 @@ import { DemoDropdown } from 'ui/components/DemoDropdown';
 import LocationList from 'ui/components/LocationList';
 import RouteMap from 'ui/components/RouteMap';
 import SearchBox, { Result } from 'ui/components/SearchBox';
+import { sideBarStyle } from 'ui/pages/common';
 
 export const ID_CLEAR_BUTTON = 'clear-button';
 export const ID_EXPORT_BUTTON = 'export-button';
@@ -159,7 +160,7 @@ export class Demo extends React.Component<DemoProps, DemoState> {
       <Split gutter={GutterSize.md} style={{ overflowY: 'auto' }}>
         <SplitItem
           isFilled={false}
-          style={{ display: 'flex', flexDirection: 'column' }}
+          style={sideBarStyle}
         >
           <TextContent>
             <Text component={TextVariants.h1}>Demo</Text>

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
@@ -30,7 +30,14 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import { MinusIcon, PlusIcon } from '@patternfly/react-icons';
+import {
+  ClockIcon,
+  IconSize,
+  MessagesIcon,
+  MinusIcon,
+  PlusIcon,
+  TruckIcon,
+} from '@patternfly/react-icons';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { clientOperations } from 'store/client';
@@ -210,11 +217,20 @@ export class Demo extends React.Component<DemoProps, DemoState> {
                             </Button>
                           </InputGroup>
                         </LevelItem>
-                        <LevelItem>vehicles</LevelItem>
+                        <LevelItem>
+                          <TruckIcon size={IconSize.md} />
+                          vehicles
+                        </LevelItem>
                       </Level>
                     </LevelItem>
-                    <LevelItem>{`${visits.length} visits`}</LevelItem>
-                    <LevelItem>{`Total travel time: ${distance}`}</LevelItem>
+                    <LevelItem>
+                      <MessagesIcon size={IconSize.md} />
+                      {`${visits.length} visits`}
+                    </LevelItem>
+                    <LevelItem>
+                      <ClockIcon size={IconSize.md} />
+                      {`Total travel time: ${distance}`}
+                    </LevelItem>
                   </Level>
                 </GridItem>
                 <GridItem span={4} />

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
@@ -17,13 +17,12 @@
 import {
   Button,
   ButtonVariant,
-  Grid,
-  GridItem,
+  Flex,
+  FlexItem,
+  FlexModifiers,
   GutterSize,
   InputGroup,
   InputGroupText,
-  Level,
-  LevelItem,
   Split,
   SplitItem,
   Text,
@@ -183,51 +182,42 @@ export class Demo extends React.Component<DemoProps, DemoState> {
           isFilled
           style={{ display: 'flex', flexDirection: 'column' }}
         >
-          <Split gutter={GutterSize.md}>
-            <SplitItem isFilled>
-              <Grid>
-                <GridItem span={8}>
-                  <Level gutter="sm">
-                    <LevelItem style={{ display: 'flex' }}>
-                      <Level gutter="sm">
-                        <LevelItem>
-                          <InputGroup>
-                            <Button
-                              variant={ButtonVariant.primary}
-                              isDisabled={vehicleCount === 0}
-                              onClick={removeVehicleHandler}
-                            >
-                              <MinusIcon />
-                            </Button>
-                            <InputGroupText readOnly>
-                              {vehicleCount}
-                            </InputGroupText>
-                            <Button
-                              variant={ButtonVariant.primary}
-                              onClick={addVehicleHandler}
-                              data-cy="demo-add-vehicle"
-                            >
-                              <PlusIcon />
-                            </Button>
-                          </InputGroup>
-                        </LevelItem>
-                        <LevelItem>
-                          <VehiclesInfo />
-                        </LevelItem>
-                      </Level>
-                    </LevelItem>
-                    <LevelItem>
-                      <VisitsInfo visitCount={visits.length} />
-                    </LevelItem>
-                    <LevelItem>
-                      <DistanceInfo distance={distance} />
-                    </LevelItem>
-                  </Level>
-                </GridItem>
-                <GridItem span={4} />
-              </Grid>
-            </SplitItem>
-            <SplitItem isFilled={false}>
+          <Flex breakpointMods={[{ modifier: FlexModifiers['justify-content-space-between'] }]}>
+            <FlexItem>
+              <Flex>
+                <FlexItem>
+                  <InputGroup>
+                    <Button
+                      variant={ButtonVariant.primary}
+                      isDisabled={vehicleCount === 0}
+                      onClick={removeVehicleHandler}
+                    >
+                      <MinusIcon />
+                    </Button>
+                    <InputGroupText readOnly>
+                      {vehicleCount}
+                    </InputGroupText>
+                    <Button
+                      variant={ButtonVariant.primary}
+                      onClick={addVehicleHandler}
+                      data-cy="demo-add-vehicle"
+                    >
+                      <PlusIcon />
+                    </Button>
+                  </InputGroup>
+                </FlexItem>
+                <FlexItem>
+                  <VehiclesInfo />
+                </FlexItem>
+              </Flex>
+            </FlexItem>
+            <FlexItem>
+              <VisitsInfo visitCount={visits.length} />
+            </FlexItem>
+            <FlexItem>
+              <DistanceInfo distance={distance} />
+            </FlexItem>
+            <FlexItem>
               <Button
                 id={ID_EXPORT_BUTTON}
                 isDisabled={!depot || isDemoLoading}
@@ -252,8 +242,8 @@ export class Demo extends React.Component<DemoProps, DemoState> {
                   Clear
                 </Button>
               )}
-            </SplitItem>
-          </Split>
+            </FlexItem>
+          </Flex>
           <RouteMap
             boundingBox={boundingBox}
             userViewport={userViewport}

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Demo.tsx
@@ -30,14 +30,7 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import {
-  ClockIcon,
-  IconSize,
-  MessagesIcon,
-  MinusIcon,
-  PlusIcon,
-  TruckIcon,
-} from '@patternfly/react-icons';
+import { MinusIcon, PlusIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { clientOperations } from 'store/client';
@@ -51,6 +44,7 @@ import LocationList from 'ui/components/LocationList';
 import RouteMap from 'ui/components/RouteMap';
 import SearchBox, { Result } from 'ui/components/SearchBox';
 import { sideBarStyle } from 'ui/pages/common';
+import { DistanceInfo, VehiclesInfo, VisitsInfo } from 'ui/pages/InfoBlock';
 
 export const ID_CLEAR_BUTTON = 'clear-button';
 export const ID_EXPORT_BUTTON = 'export-button';
@@ -218,18 +212,15 @@ export class Demo extends React.Component<DemoProps, DemoState> {
                           </InputGroup>
                         </LevelItem>
                         <LevelItem>
-                          <TruckIcon size={IconSize.md} />
-                          vehicles
+                          <VehiclesInfo />
                         </LevelItem>
                       </Level>
                     </LevelItem>
                     <LevelItem>
-                      <MessagesIcon size={IconSize.md} />
-                      {`${visits.length} visits`}
+                      <VisitsInfo visitCount={visits.length} />
                     </LevelItem>
                     <LevelItem>
-                      <ClockIcon size={IconSize.md} />
-                      {`Total travel time: ${distance}`}
+                      <DistanceInfo distance={distance} />
                     </LevelItem>
                   </Level>
                 </GridItem>

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.test.tsx
@@ -22,7 +22,7 @@ import { DistanceInfo, InfoBlock, VehiclesInfo, VisitsInfo } from 'ui/pages/Info
 
 describe('Info block snapshots:', () => {
   it('generic', () => {
-    const infoBlock = shallow(<InfoBlock icon={PlusIcon} content="test content" />);
+    const infoBlock = shallow(<InfoBlock icon={PlusIcon} data="test content" tooltip="test tooltip" />);
     expect(toJson(infoBlock)).toMatchSnapshot();
   });
   it('vehicles', () => {

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PlusIcon } from '@patternfly/react-icons';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import * as React from 'react';
+import { DistanceInfo, InfoBlock, VehiclesInfo, VisitsInfo } from 'ui/pages/InfoBlock';
+
+describe('Info block snapshots:', () => {
+  it('generic', () => {
+    const infoBlock = shallow(<InfoBlock icon={PlusIcon} content="test content" />);
+    expect(toJson(infoBlock)).toMatchSnapshot();
+  });
+  it('vehicles', () => {
+    const vehiclesInfo = shallow(<VehiclesInfo />);
+    expect(toJson(vehiclesInfo)).toMatchSnapshot();
+  });
+  it('visits', () => {
+    const visitsInfo = shallow(<VisitsInfo visitCount={300} />);
+    expect(toJson(visitsInfo)).toMatchSnapshot();
+  });
+  it('distance', () => {
+    const distanceInfo = shallow(<DistanceInfo distance="3h 56m 11s" />);
+    expect(toJson(distanceInfo)).toMatchSnapshot();
+  });
+});

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.tsx
@@ -14,32 +14,37 @@
  * limitations under the License.
  */
 
-import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
+import { Flex, FlexItem, FlexModifiers, Tooltip } from '@patternfly/react-core';
 import { ClockIcon, IconSize, MessagesIcon, TruckIcon } from '@patternfly/react-icons';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import * as React from 'react';
 
 interface InfoBlockProps {
   icon: IconType;
-  content: string;
+  data?: string | number;
+  tooltip: string;
 }
 
-export const InfoBlock = ({ icon, content }: InfoBlockProps) => {
+export const InfoBlock = ({ icon, data, tooltip }: InfoBlockProps) => {
   const Icon = icon;
   return (
-    <Flex breakpointMods={[{ modifier: FlexModifiers['space-items-sm'] }]}>
-      <FlexItem>
-        <Icon size={IconSize.md} />
-      </FlexItem>
-      <FlexItem>
-        {content}
-      </FlexItem>
-    </Flex>
+    <Tooltip content={tooltip} position="bottom">
+      <Flex breakpointMods={[{ modifier: FlexModifiers['space-items-sm'] }]}>
+        <FlexItem>
+          <Icon size={IconSize.md} />
+        </FlexItem>
+        {data && (
+          <FlexItem>
+            {data}
+          </FlexItem>
+        )}
+      </Flex>
+    </Tooltip>
   );
 };
 
 export const VehiclesInfo = () => (
-  <InfoBlock icon={TruckIcon} content="vehicles" />
+  <InfoBlock icon={TruckIcon} tooltip="Vehicles" />
 );
 
 interface VisitInfoProps {
@@ -47,7 +52,7 @@ interface VisitInfoProps {
 }
 
 export const VisitsInfo = ({ visitCount }: VisitInfoProps) => (
-  <InfoBlock icon={MessagesIcon} content={`${visitCount} visits`} />
+  <InfoBlock icon={MessagesIcon} data={visitCount} tooltip="Number of visits" />
 );
 
 interface DistanceInfoProps {
@@ -55,5 +60,5 @@ interface DistanceInfoProps {
 }
 
 export const DistanceInfo = ({ distance }: DistanceInfoProps) => (
-  <InfoBlock icon={ClockIcon} content={`Total travel time: ${distance}`} />
+  <InfoBlock icon={ClockIcon} data={distance} tooltip="Total travel time" />
 );

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ClockIcon, IconSize, MessagesIcon, TruckIcon } from '@patternfly/react-icons';
+import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
+import * as React from 'react';
+
+interface InfoBlockProps {
+  icon: IconType;
+  content: string;
+}
+
+export const InfoBlock = ({ icon, content }: InfoBlockProps) => {
+  const Icon = icon;
+  return (
+    <>
+      <Icon size={IconSize.md} />
+      {content}
+    </>
+  );
+};
+
+export const VehiclesInfo = () => (
+  <InfoBlock icon={TruckIcon} content="vehicles" />
+);
+
+interface VisitInfoProps {
+  visitCount: number;
+}
+
+export const VisitsInfo = ({ visitCount }: VisitInfoProps) => (
+  <InfoBlock icon={MessagesIcon} content={`${visitCount} visits`} />
+);
+
+interface DistanceInfoProps {
+  distance: string;
+}
+
+export const DistanceInfo = ({ distance }: DistanceInfoProps) => (
+  <InfoBlock icon={ClockIcon} content={`Total travel time: ${distance}`} />
+);

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/InfoBlock.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import { ClockIcon, IconSize, MessagesIcon, TruckIcon } from '@patternfly/react-icons';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import * as React from 'react';
@@ -26,10 +27,14 @@ interface InfoBlockProps {
 export const InfoBlock = ({ icon, content }: InfoBlockProps) => {
   const Icon = icon;
   return (
-    <>
-      <Icon size={IconSize.md} />
-      {content}
-    </>
+    <Flex breakpointMods={[{ modifier: FlexModifiers['space-items-sm'] }]}>
+      <FlexItem>
+        <Icon size={IconSize.md} />
+      </FlexItem>
+      <FlexItem>
+        {content}
+      </FlexItem>
+    </Flex>
   );
 };
 

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/Route.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/Route.tsx
@@ -34,6 +34,7 @@ import { LatLng, Location, RouteWithTrack } from 'store/route/types';
 import { AppState } from 'store/types';
 import LocationList from 'ui/components/LocationList';
 import RouteMap from 'ui/components/RouteMap';
+import { sideBarStyle } from 'ui/pages/common';
 
 export interface StateProps {
   depot: Location | null;
@@ -115,7 +116,7 @@ export class Route extends React.Component<RouteProps, RouteState> {
         <Split gutter={GutterSize.md}>
           <SplitItem
             isFilled={false}
-            style={{ display: 'flex', flexDirection: 'column' }}
+            style={sideBarStyle}
           >
             <Form>
               <FormSelect

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
@@ -128,33 +128,19 @@ exports[`Demo page clear and export buttons should be disabled when demo is load
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
-                    <TruckIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="md"
-                      title={null}
-                    />
-                    vehicles
+                    <VehiclesInfo />
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
-                <MessagesIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <VisitsInfo
+                  visitCount={2}
                 />
-                2 visits
               </LevelItem>
               <LevelItem>
-                <ClockIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <DistanceInfo
+                  distance="10"
                 />
-                Total travel time: 10
               </LevelItem>
             </Level>
           </GridItem>
@@ -378,33 +364,19 @@ exports[`Demo page clear button should replace demo dropdown as soon as there is
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
-                    <TruckIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="md"
-                      title={null}
-                    />
-                    vehicles
+                    <VehiclesInfo />
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
-                <MessagesIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <VisitsInfo
+                  visitCount={0}
                 />
-                0 visits
               </LevelItem>
               <LevelItem>
-                <ClockIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <DistanceInfo
+                  distance="0"
                 />
-                Total travel time: 0
               </LevelItem>
             </Level>
           </GridItem>
@@ -604,33 +576,19 @@ exports[`Demo page should render correctly with a few routes 1`] = `
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
-                    <TruckIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="md"
-                      title={null}
-                    />
-                    vehicles
+                    <VehiclesInfo />
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
-                <MessagesIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <VisitsInfo
+                  visitCount={2}
                 />
-                2 visits
               </LevelItem>
               <LevelItem>
-                <ClockIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <DistanceInfo
+                  distance="10"
                 />
-                Total travel time: 10
               </LevelItem>
             </Level>
           </GridItem>
@@ -847,33 +805,19 @@ exports[`Demo page should render correctly with no routes 1`] = `
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
-                    <TruckIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="md"
-                      title={null}
-                    />
-                    vehicles
+                    <VehiclesInfo />
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
-                <MessagesIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <VisitsInfo
+                  visitCount={0}
                 />
-                0 visits
               </LevelItem>
               <LevelItem>
-                <ClockIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="md"
-                  title={null}
+                <DistanceInfo
+                  distance="0"
                 />
-                Total travel time: 0
               </LevelItem>
             </Level>
           </GridItem>

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
@@ -128,14 +128,32 @@ exports[`Demo page clear and export buttons should be disabled when demo is load
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
+                    <TruckIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="md"
+                      title={null}
+                    />
                     vehicles
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
+                <MessagesIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 2 visits
               </LevelItem>
               <LevelItem>
+                <ClockIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 Total travel time: 10
               </LevelItem>
             </Level>
@@ -360,14 +378,32 @@ exports[`Demo page clear button should replace demo dropdown as soon as there is
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
+                    <TruckIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="md"
+                      title={null}
+                    />
                     vehicles
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
+                <MessagesIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 0 visits
               </LevelItem>
               <LevelItem>
+                <ClockIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 Total travel time: 0
               </LevelItem>
             </Level>
@@ -568,14 +604,32 @@ exports[`Demo page should render correctly with a few routes 1`] = `
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
+                    <TruckIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="md"
+                      title={null}
+                    />
                     vehicles
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
+                <MessagesIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 2 visits
               </LevelItem>
               <LevelItem>
+                <ClockIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 Total travel time: 10
               </LevelItem>
             </Level>
@@ -793,14 +847,32 @@ exports[`Demo page should render correctly with no routes 1`] = `
                     </InputGroup>
                   </LevelItem>
                   <LevelItem>
+                    <TruckIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="md"
+                      title={null}
+                    />
                     vehicles
                   </LevelItem>
                 </Level>
               </LevelItem>
               <LevelItem>
+                <MessagesIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 0 visits
               </LevelItem>
               <LevelItem>
+                <ClockIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="md"
+                  title={null}
+                />
                 Total travel time: 0
               </LevelItem>
             </Level>

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
@@ -71,87 +71,66 @@ exports[`Demo page clear and export buttons should be disabled when demo is load
       }
     }
   >
-    <Split
-      gutter="md"
+    <Flex
+      breakpointMods={
+        Array [
+          Object {
+            "modifier": "justify-content-space-between",
+          },
+        ]
+      }
     >
-      <SplitItem
-        isFilled={true}
-      >
-        <Grid>
-          <GridItem
-            span={8}
-          >
-            <Level
-              gutter="sm"
-            >
-              <LevelItem
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
+      <FlexItem>
+        <Flex>
+          <FlexItem>
+            <InputGroup>
+              <Component
+                isDisabled={false}
+                onClick={[Function]}
+                variant="primary"
               >
-                <Level
-                  gutter="sm"
-                >
-                  <LevelItem>
-                    <InputGroup>
-                      <Component
-                        isDisabled={false}
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <MinusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                      <InputGroupText
-                        readOnly={true}
-                      >
-                        8
-                      </InputGroupText>
-                      <Component
-                        data-cy="demo-add-vehicle"
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <PlusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                    </InputGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <VehiclesInfo />
-                  </LevelItem>
-                </Level>
-              </LevelItem>
-              <LevelItem>
-                <VisitsInfo
-                  visitCount={2}
+                <MinusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-              <LevelItem>
-                <DistanceInfo
-                  distance="10"
+              </Component>
+              <InputGroupText
+                readOnly={true}
+              >
+                8
+              </InputGroupText>
+              <Component
+                data-cy="demo-add-vehicle"
+                onClick={[Function]}
+                variant="primary"
+              >
+                <PlusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-            </Level>
-          </GridItem>
-          <GridItem
-            span={4}
-          />
-        </Grid>
-      </SplitItem>
-      <SplitItem
-        isFilled={false}
-      >
+              </Component>
+            </InputGroup>
+          </FlexItem>
+          <FlexItem>
+            <VehiclesInfo />
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+      <FlexItem>
+        <VisitsInfo
+          visitCount={2}
+        />
+      </FlexItem>
+      <FlexItem>
+        <DistanceInfo
+          distance="10"
+        />
+      </FlexItem>
+      <FlexItem>
         <Component
           id="export-button"
           isDisabled={true}
@@ -179,8 +158,8 @@ exports[`Demo page clear and export buttons should be disabled when demo is load
         >
           Clear
         </Component>
-      </SplitItem>
-    </Split>
+      </FlexItem>
+    </Flex>
     <RouteMap
       boundingBox={null}
       clickHandler={[Function]}
@@ -307,87 +286,66 @@ exports[`Demo page clear button should replace demo dropdown as soon as there is
       }
     }
   >
-    <Split
-      gutter="md"
+    <Flex
+      breakpointMods={
+        Array [
+          Object {
+            "modifier": "justify-content-space-between",
+          },
+        ]
+      }
     >
-      <SplitItem
-        isFilled={true}
-      >
-        <Grid>
-          <GridItem
-            span={8}
-          >
-            <Level
-              gutter="sm"
-            >
-              <LevelItem
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
+      <FlexItem>
+        <Flex>
+          <FlexItem>
+            <InputGroup>
+              <Component
+                isDisabled={true}
+                onClick={[Function]}
+                variant="primary"
               >
-                <Level
-                  gutter="sm"
-                >
-                  <LevelItem>
-                    <InputGroup>
-                      <Component
-                        isDisabled={true}
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <MinusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                      <InputGroupText
-                        readOnly={true}
-                      >
-                        0
-                      </InputGroupText>
-                      <Component
-                        data-cy="demo-add-vehicle"
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <PlusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                    </InputGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <VehiclesInfo />
-                  </LevelItem>
-                </Level>
-              </LevelItem>
-              <LevelItem>
-                <VisitsInfo
-                  visitCount={0}
+                <MinusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-              <LevelItem>
-                <DistanceInfo
-                  distance="0"
+              </Component>
+              <InputGroupText
+                readOnly={true}
+              >
+                0
+              </InputGroupText>
+              <Component
+                data-cy="demo-add-vehicle"
+                onClick={[Function]}
+                variant="primary"
+              >
+                <PlusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-            </Level>
-          </GridItem>
-          <GridItem
-            span={4}
-          />
-        </Grid>
-      </SplitItem>
-      <SplitItem
-        isFilled={false}
-      >
+              </Component>
+            </InputGroup>
+          </FlexItem>
+          <FlexItem>
+            <VehiclesInfo />
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+      <FlexItem>
+        <VisitsInfo
+          visitCount={0}
+        />
+      </FlexItem>
+      <FlexItem>
+        <DistanceInfo
+          distance="0"
+        />
+      </FlexItem>
+      <FlexItem>
         <Component
           id="export-button"
           isDisabled={false}
@@ -415,8 +373,8 @@ exports[`Demo page clear button should replace demo dropdown as soon as there is
         >
           Clear
         </Component>
-      </SplitItem>
-    </Split>
+      </FlexItem>
+    </Flex>
     <RouteMap
       boundingBox={null}
       clickHandler={[Function]}
@@ -519,87 +477,66 @@ exports[`Demo page should render correctly with a few routes 1`] = `
       }
     }
   >
-    <Split
-      gutter="md"
+    <Flex
+      breakpointMods={
+        Array [
+          Object {
+            "modifier": "justify-content-space-between",
+          },
+        ]
+      }
     >
-      <SplitItem
-        isFilled={true}
-      >
-        <Grid>
-          <GridItem
-            span={8}
-          >
-            <Level
-              gutter="sm"
-            >
-              <LevelItem
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
+      <FlexItem>
+        <Flex>
+          <FlexItem>
+            <InputGroup>
+              <Component
+                isDisabled={false}
+                onClick={[Function]}
+                variant="primary"
               >
-                <Level
-                  gutter="sm"
-                >
-                  <LevelItem>
-                    <InputGroup>
-                      <Component
-                        isDisabled={false}
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <MinusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                      <InputGroupText
-                        readOnly={true}
-                      >
-                        8
-                      </InputGroupText>
-                      <Component
-                        data-cy="demo-add-vehicle"
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <PlusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                    </InputGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <VehiclesInfo />
-                  </LevelItem>
-                </Level>
-              </LevelItem>
-              <LevelItem>
-                <VisitsInfo
-                  visitCount={2}
+                <MinusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-              <LevelItem>
-                <DistanceInfo
-                  distance="10"
+              </Component>
+              <InputGroupText
+                readOnly={true}
+              >
+                8
+              </InputGroupText>
+              <Component
+                data-cy="demo-add-vehicle"
+                onClick={[Function]}
+                variant="primary"
+              >
+                <PlusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-            </Level>
-          </GridItem>
-          <GridItem
-            span={4}
-          />
-        </Grid>
-      </SplitItem>
-      <SplitItem
-        isFilled={false}
-      >
+              </Component>
+            </InputGroup>
+          </FlexItem>
+          <FlexItem>
+            <VehiclesInfo />
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+      <FlexItem>
+        <VisitsInfo
+          visitCount={2}
+        />
+      </FlexItem>
+      <FlexItem>
+        <DistanceInfo
+          distance="10"
+        />
+      </FlexItem>
+      <FlexItem>
         <Component
           id="export-button"
           isDisabled={false}
@@ -627,8 +564,8 @@ exports[`Demo page should render correctly with a few routes 1`] = `
         >
           Clear
         </Component>
-      </SplitItem>
-    </Split>
+      </FlexItem>
+    </Flex>
     <RouteMap
       boundingBox={null}
       clickHandler={[Function]}
@@ -748,87 +685,66 @@ exports[`Demo page should render correctly with no routes 1`] = `
       }
     }
   >
-    <Split
-      gutter="md"
+    <Flex
+      breakpointMods={
+        Array [
+          Object {
+            "modifier": "justify-content-space-between",
+          },
+        ]
+      }
     >
-      <SplitItem
-        isFilled={true}
-      >
-        <Grid>
-          <GridItem
-            span={8}
-          >
-            <Level
-              gutter="sm"
-            >
-              <LevelItem
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
+      <FlexItem>
+        <Flex>
+          <FlexItem>
+            <InputGroup>
+              <Component
+                isDisabled={true}
+                onClick={[Function]}
+                variant="primary"
               >
-                <Level
-                  gutter="sm"
-                >
-                  <LevelItem>
-                    <InputGroup>
-                      <Component
-                        isDisabled={true}
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <MinusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                      <InputGroupText
-                        readOnly={true}
-                      >
-                        0
-                      </InputGroupText>
-                      <Component
-                        data-cy="demo-add-vehicle"
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        <PlusIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        />
-                      </Component>
-                    </InputGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <VehiclesInfo />
-                  </LevelItem>
-                </Level>
-              </LevelItem>
-              <LevelItem>
-                <VisitsInfo
-                  visitCount={0}
+                <MinusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-              <LevelItem>
-                <DistanceInfo
-                  distance="0"
+              </Component>
+              <InputGroupText
+                readOnly={true}
+              >
+                0
+              </InputGroupText>
+              <Component
+                data-cy="demo-add-vehicle"
+                onClick={[Function]}
+                variant="primary"
+              >
+                <PlusIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
                 />
-              </LevelItem>
-            </Level>
-          </GridItem>
-          <GridItem
-            span={4}
-          />
-        </Grid>
-      </SplitItem>
-      <SplitItem
-        isFilled={false}
-      >
+              </Component>
+            </InputGroup>
+          </FlexItem>
+          <FlexItem>
+            <VehiclesInfo />
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+      <FlexItem>
+        <VisitsInfo
+          visitCount={0}
+        />
+      </FlexItem>
+      <FlexItem>
+        <DistanceInfo
+          distance="0"
+        />
+      </FlexItem>
+      <FlexItem>
         <Component
           id="export-button"
           isDisabled={true}
@@ -850,8 +766,8 @@ exports[`Demo page should render correctly with no routes 1`] = `
           }
           onSelect={[Function]}
         />
-      </SplitItem>
-    </Split>
+      </FlexItem>
+    </Flex>
     <RouteMap
       boundingBox={null}
       clickHandler={[Function]}

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Demo.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Demo page clear and export buttons should be disabled when demo is load
       Object {
         "display": "flex",
         "flexDirection": "column",
+        "width": "320px",
       }
     }
   >
@@ -262,6 +263,7 @@ exports[`Demo page clear button should replace demo dropdown as soon as there is
       Object {
         "display": "flex",
         "flexDirection": "column",
+        "width": "320px",
       }
     }
   >
@@ -453,6 +455,7 @@ exports[`Demo page should render correctly with a few routes 1`] = `
       Object {
         "display": "flex",
         "flexDirection": "column",
+        "width": "320px",
       }
     }
   >
@@ -700,6 +703,7 @@ exports[`Demo page should render correctly with no routes 1`] = `
       Object {
         "display": "flex",
         "flexDirection": "column",
+        "width": "320px",
       }
     }
   >

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/InfoBlock.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/InfoBlock.test.tsx.snap
@@ -2,45 +2,79 @@
 
 exports[`Info block snapshots: distance 1`] = `
 <InfoBlock
-  content="Total travel time: 3h 56m 11s"
+  data="3h 56m 11s"
   icon={[Function]}
+  tooltip="Total travel time"
 />
 `;
 
 exports[`Info block snapshots: generic 1`] = `
-<Flex
-  breakpointMods={
+<Tooltip
+  appendTo={[Function]}
+  aria="describedby"
+  boundary="window"
+  className=""
+  content="test tooltip"
+  distance={15}
+  enableFlip={true}
+  entryDelay={500}
+  exitDelay={500}
+  flipBehavior={
     Array [
-      Object {
-        "modifier": "space-items-sm",
-      },
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "top",
+      "right",
+      "bottom",
     ]
   }
+  id=""
+  isAppLauncher={false}
+  isContentLeftAligned={false}
+  isVisible={false}
+  maxWidth="18.75rem"
+  position="bottom"
+  tippyProps={Object {}}
+  trigger="mouseenter focus"
+  zIndex={9999}
 >
-  <FlexItem>
-    <PlusIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="md"
-      title={null}
-    />
-  </FlexItem>
-  <FlexItem>
-    test content
-  </FlexItem>
-</Flex>
+  <Flex
+    breakpointMods={
+      Array [
+        Object {
+          "modifier": "space-items-sm",
+        },
+      ]
+    }
+  >
+    <FlexItem>
+      <PlusIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="md"
+        title={null}
+      />
+    </FlexItem>
+    <FlexItem>
+      test content
+    </FlexItem>
+  </Flex>
+</Tooltip>
 `;
 
 exports[`Info block snapshots: vehicles 1`] = `
 <InfoBlock
-  content="vehicles"
   icon={[Function]}
+  tooltip="Vehicles"
 />
 `;
 
 exports[`Info block snapshots: visits 1`] = `
 <InfoBlock
-  content="300 visits"
+  data={300}
   icon={[Function]}
+  tooltip="Number of visits"
 />
 `;

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/InfoBlock.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/InfoBlock.test.tsx.snap
@@ -8,15 +8,27 @@ exports[`Info block snapshots: distance 1`] = `
 `;
 
 exports[`Info block snapshots: generic 1`] = `
-<Fragment>
-  <PlusIcon
-    color="currentColor"
-    noVerticalAlign={false}
-    size="md"
-    title={null}
-  />
-  test content
-</Fragment>
+<Flex
+  breakpointMods={
+    Array [
+      Object {
+        "modifier": "space-items-sm",
+      },
+    ]
+  }
+>
+  <FlexItem>
+    <PlusIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="md"
+      title={null}
+    />
+  </FlexItem>
+  <FlexItem>
+    test content
+  </FlexItem>
+</Flex>
 `;
 
 exports[`Info block snapshots: vehicles 1`] = `

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/InfoBlock.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/InfoBlock.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Info block snapshots: distance 1`] = `
+<InfoBlock
+  content="Total travel time: 3h 56m 11s"
+  icon={[Function]}
+/>
+`;
+
+exports[`Info block snapshots: generic 1`] = `
+<Fragment>
+  <PlusIcon
+    color="currentColor"
+    noVerticalAlign={false}
+    size="md"
+    title={null}
+  />
+  test content
+</Fragment>
+`;
+
+exports[`Info block snapshots: vehicles 1`] = `
+<InfoBlock
+  content="vehicles"
+  icon={[Function]}
+/>
+`;
+
+exports[`Info block snapshots: visits 1`] = `
+<InfoBlock
+  content="300 visits"
+  icon={[Function]}
+/>
+`;

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Route.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/__snapshots__/Route.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Route page should render correctly with a few routes 1`] = `
         Object {
           "display": "flex",
           "flexDirection": "column",
+          "width": "320px",
         }
       }
     >
@@ -192,6 +193,7 @@ exports[`Route page should render correctly with no routes 1`] = `
         Object {
           "display": "flex",
           "flexDirection": "column",
+          "width": "320px",
         }
       }
     >

--- a/optaweb-vehicle-routing-frontend/src/ui/pages/common.ts
+++ b/optaweb-vehicle-routing-frontend/src/ui/pages/common.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const sideBarStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  width: '320px',
+};


### PR DESCRIPTION
Additional improvements:
- Made location list width fixed.
- Added icons to info blocks (vehicles, visits, distance).
- Added `npm run update-snapshots` script that just runs tests and updates snapshots in non-interactive mode.