### PR TITLE
PLANNER-1469: Propagate backend errors to the UI

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteChangedEventPublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteChangedEventPublisher.java
@@ -39,14 +39,14 @@ import org.springframework.stereotype.Component;
  * components that listen for this type of event.
  */
 @Component
-class SolutionPublisher {
+class RouteChangedEventPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(SolutionPublisher.class);
+    private static final Logger logger = LoggerFactory.getLogger(RouteChangedEventPublisher.class);
 
     private final ApplicationEventPublisher eventPublisher;
 
     @Autowired
-    SolutionPublisher(ApplicationEventPublisher eventPublisher) {
+    RouteChangedEventPublisher(ApplicationEventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerConfig.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerConfig.java
@@ -21,7 +21,7 @@ import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 
 /**
@@ -42,7 +42,7 @@ class RouteOptimizerConfig {
     }
 
     @Bean
-    AsyncTaskExecutor executor() {
+    AsyncListenableTaskExecutor executor() {
         SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
         executor.setConcurrencyLimit(1);
         return executor;

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImpl.java
@@ -43,16 +43,16 @@ import org.springframework.stereotype.Component;
 class RouteOptimizerImpl implements RouteOptimizer {
 
     private final SolverManager solverManager;
-    private final SolutionPublisher solutionPublisher;
+    private final RouteChangedEventPublisher routeChangedEventPublisher;
 
     private final List<PlanningVehicle> vehicles = new ArrayList<>();
     private final List<PlanningVisit> visits = new ArrayList<>();
     private PlanningDepot depot;
 
     @Autowired
-    RouteOptimizerImpl(SolverManager solverManager, SolutionPublisher solutionPublisher) {
+    RouteOptimizerImpl(SolverManager solverManager, RouteChangedEventPublisher routeChangedEventPublisher) {
         this.solverManager = solverManager;
-        this.solutionPublisher = solutionPublisher;
+        this.routeChangedEventPublisher = routeChangedEventPublisher;
     }
 
     @Override
@@ -173,6 +173,6 @@ class RouteOptimizerImpl implements RouteOptimizer {
     }
 
     private void publishSolution() {
-        solutionPublisher.publishSolution(SolutionFactory.solutionFromVisits(vehicles, depot, visits));
+        routeChangedEventPublisher.publishSolution(SolutionFactory.solutionFromVisits(vehicles, depot, visits));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableErrorMessage.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableErrorMessage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.websocket;
+
+import java.util.Objects;
+
+import org.optaweb.vehiclerouting.service.error.ErrorMessage;
+
+/**
+ * Portable error message.
+ */
+public class PortableErrorMessage {
+
+    private final String id;
+    private final String text;
+
+    static PortableErrorMessage fromMessage(ErrorMessage message) {
+        return new PortableErrorMessage(message.id, message.text);
+    }
+
+    PortableErrorMessage(String id, String text) {
+        this.id = id;
+        this.text = text;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PortableErrorMessage that = (PortableErrorMessage) o;
+        return id.equals(that.id) &&
+                text.equals(that.text);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, text);
+    }
+
+    @Override
+    public String toString() {
+        return "PortableErrorMessage{" +
+                "id='" + id + '\'' +
+                ", text='" + text + '\'' +
+                '}';
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorMessageSender.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorMessageSender.java
@@ -16,25 +16,29 @@
 
 package org.optaweb.vehiclerouting.plugin.websocket;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.service.error.ErrorMessage;
+import org.optaweb.vehiclerouting.service.error.ErrorMessageConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
 
-import static org.mockito.Mockito.verify;
+/**
+ * Broadcasts application errors to interested clients over WebSocket.
+ */
+@Component
+class WebSocketErrorMessageSender implements ErrorMessageConsumer {
 
-@ExtendWith(MockitoExtension.class)
-class WebSocketErrorPublisherTest {
+    static final String TOPIC_ERROR = "/topic/error";
 
-    @Test
-    void publish(@Mock SimpMessagingTemplate webSocket) {
-        ErrorMessage message = ErrorMessage.of("id", "error");
-        new WebSocketErrorPublisher(webSocket).publishError(message);
-        verify(webSocket).convertAndSend(
-                WebSocketErrorPublisher.TOPIC_ERROR,
-                PortableErrorMessage.fromMessage(message)
-        );
+    private final SimpMessagingTemplate webSocket;
+
+    @Autowired
+    WebSocketErrorMessageSender(SimpMessagingTemplate webSocket) {
+        this.webSocket = webSocket;
+    }
+
+    @Override
+    public void consumeMessage(ErrorMessage message) {
+        webSocket.convertAndSend(TOPIC_ERROR, PortableErrorMessage.fromMessage(message));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisher.java
@@ -16,6 +16,7 @@
 
 package org.optaweb.vehiclerouting.plugin.websocket;
 
+import org.optaweb.vehiclerouting.service.error.ErrorMessage;
 import org.optaweb.vehiclerouting.service.error.ErrorPublisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -27,6 +28,8 @@ import org.springframework.stereotype.Component;
 @Component
 class WebSocketErrorPublisher implements ErrorPublisher {
 
+    static final String TOPIC_ERROR = "/topic/error";
+
     private final SimpMessagingTemplate webSocket;
 
     @Autowired
@@ -35,7 +38,7 @@ class WebSocketErrorPublisher implements ErrorPublisher {
     }
 
     @Override
-    public void publishError(String message) {
-        webSocket.convertAndSend("/topic/error", message);
+    public void publishError(ErrorMessage message) {
+        webSocket.convertAndSend(TOPIC_ERROR, PortableErrorMessage.fromMessage(message));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisher.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.websocket;
+
+import org.optaweb.vehiclerouting.service.error.ErrorPublisher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Broadcasts application errors to interested clients over WebSocket.
+ */
+@Component
+class WebSocketErrorPublisher implements ErrorPublisher {
+
+    private final SimpMessagingTemplate webSocket;
+
+    @Autowired
+    WebSocketErrorPublisher(SimpMessagingTemplate webSocket) {
+        this.webSocket = webSocket;
+    }
+
+    @Override
+    public void publishError(String message) {
+        webSocket.convertAndSend("/topic/error", message);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/distance/DistanceMatrixImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/distance/DistanceMatrixImpl.java
@@ -55,16 +55,16 @@ class DistanceMatrixImpl implements DistanceMatrix {
         // distance to self is 0
         distancesToOthers.put(newLocation.id(), Distance.ZERO);
 
-        // for all entries (rows) in the matrix:
+        // For all entries (rows) in the matrix:
         matrix.entrySet().stream().parallel().forEach(distanceRow -> {
-            // entry key is the existing (other) location
+            // Entry key is the existing (other) location.
             Location other = distanceRow.getKey();
-            // entry value is the data (cells) in the row (distances from the entry key location to any other)
-            Map<Long, Distance> distancesFromOther = distanceRow.getValue();
-            // add a new cell to the row with the distance from the entry key location to the new location
-            // (results in a new column at the end of the loop)
-            distancesFromOther.put(newLocation.id(), calculateOrRestoreDistance(other, newLocation));
-            // add a cell the new distance's row
+            // Entry value is the data (cells) in the row (distances from the entry key location to any other).
+            Map<Long, Distance> distancesFromOthers = distanceRow.getValue();
+            // Add a new cell to the row with the distance from the entry key location to the new location
+            // (results in a new column at the end of the loop).
+            distancesFromOthers.put(newLocation.id(), calculateOrRestoreDistance(other, newLocation));
+            // Add a cell to the new distance's row.
             distancesToOthers.put(other.id(), calculateOrRestoreDistance(newLocation, other));
         });
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorEvent.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.error;
+
+import java.util.Objects;
+
+import org.springframework.context.ApplicationEvent;
+
+public class ErrorEvent extends ApplicationEvent {
+
+    public final String message;
+
+    /**
+     * Create a new {@code ApplicationEvent}.
+     * @param source the object on which the event initially occurred or with
+     * which the event is associated (never {@code null})
+     * @param message error message (never {@code null})
+     */
+    public ErrorEvent(Object source, String message) {
+        super(source);
+        this.message = Objects.requireNonNull(message);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorListener.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.error;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * Handles error events.
+ */
+@Service
+public class ErrorListener implements ApplicationListener<ErrorEvent> {
+
+    private final ErrorPublisher errorPublisher;
+
+    public ErrorListener(ErrorPublisher errorPublisher) {
+        this.errorPublisher = errorPublisher;
+    }
+
+    @Override
+    public void onApplicationEvent(ErrorEvent event) {
+        errorPublisher.publishError(event.message);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorListener.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorListener.java
@@ -22,19 +22,19 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Service;
 
 /**
- * Handles error events.
+ * Creates messages from error events and passes them to consumers.
  */
 @Service
 public class ErrorListener implements ApplicationListener<ErrorEvent> {
 
-    private final ErrorPublisher errorPublisher;
+    private final ErrorMessageConsumer errorMessageConsumer;
 
-    public ErrorListener(ErrorPublisher errorPublisher) {
-        this.errorPublisher = errorPublisher;
+    public ErrorListener(ErrorMessageConsumer errorMessageConsumer) {
+        this.errorMessageConsumer = errorMessageConsumer;
     }
 
     @Override
     public void onApplicationEvent(ErrorEvent event) {
-        errorPublisher.publishError(ErrorMessage.of(UUID.randomUUID().toString(), event.message));
+        errorMessageConsumer.consumeMessage(ErrorMessage.of(UUID.randomUUID().toString(), event.message));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorMessage.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorMessage.java
@@ -16,25 +16,25 @@
 
 package org.optaweb.vehiclerouting.service.error;
 
-import java.util.UUID;
+import java.util.Objects;
 
-import org.springframework.context.ApplicationListener;
-import org.springframework.stereotype.Service;
+public class ErrorMessage {
 
-/**
- * Handles error events.
- */
-@Service
-public class ErrorListener implements ApplicationListener<ErrorEvent> {
+    /**
+     * Message ID (never {@code null}).
+     */
+    public final String id;
+    /**
+     * Message text (never {@code null}).
+     */
+    public final String text;
 
-    private final ErrorPublisher errorPublisher;
-
-    public ErrorListener(ErrorPublisher errorPublisher) {
-        this.errorPublisher = errorPublisher;
+    public static ErrorMessage of(String id, String text) {
+        return new ErrorMessage(id, text);
     }
 
-    @Override
-    public void onApplicationEvent(ErrorEvent event) {
-        errorPublisher.publishError(ErrorMessage.of(UUID.randomUUID().toString(), event.message));
+    private ErrorMessage(String id, String text) {
+        this.id = Objects.requireNonNull(id);
+        this.text = Objects.requireNonNull(text);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorMessageConsumer.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorMessageConsumer.java
@@ -17,13 +17,13 @@
 package org.optaweb.vehiclerouting.service.error;
 
 /**
- * Publishes errors to clients.
+ * Consumes error messages.
  */
-public interface ErrorPublisher {
+public interface ErrorMessageConsumer {
 
     /**
-     * Publish an error.
+     * Consume an error message.
      * @param message error message
      */
-    void publishError(ErrorMessage message);
+    void consumeMessage(ErrorMessage message);
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorPublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorPublisher.java
@@ -25,5 +25,5 @@ public interface ErrorPublisher {
      * Publish an error.
      * @param message error message
      */
-    void publishError(String message);
+    void publishError(ErrorMessage message);
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorPublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/ErrorPublisher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.error;
+
+/**
+ * Publishes errors to clients.
+ */
+public interface ErrorPublisher {
+
+    /**
+     * Publish an error.
+     * @param message error message
+     */
+    void publishError(String message);
+}

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/package-info.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/error/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Handles error events. For example an uncaught exception can be turned into an error event that is sent to the client.
+ */
+package org.optaweb.vehiclerouting.service.error;

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RoutePublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RoutePublisher.java
@@ -21,7 +21,7 @@ import org.optaweb.vehiclerouting.domain.RoutingPlan;
 /**
  * Publishes routing plan to clients.
  */
-public interface RoutePublisher {
+public interface RoutePublisher { // TODO rename to RouteConsumer
 
     /**
      * Publish the routing plan.

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteChangedEventPublisherTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteChangedEventPublisherTest.java
@@ -45,16 +45,16 @@ import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFact
 import static org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory.solutionFromVisits;
 
 @ExtendWith(MockitoExtension.class)
-class SolutionPublisherTest {
+class RouteChangedEventPublisherTest {
 
     @Mock
     private ApplicationEventPublisher publisher;
     @InjectMocks
-    private SolutionPublisher solutionPublisher;
+    private RouteChangedEventPublisher routeChangedEventPublisher;
 
     @Test
     void should_covert_solution_to_event_and_publish_it() {
-        solutionPublisher.publishSolution(SolutionFactory.emptySolution());
+        routeChangedEventPublisher.publishSolution(SolutionFactory.emptySolution());
         verify(publisher).publishEvent(any(RouteChangedEvent.class));
     }
 
@@ -62,7 +62,7 @@ class SolutionPublisherTest {
     void empty_solution_should_have_zero_routes_vehicles_etc() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
 
-        RouteChangedEvent event = SolutionPublisher.solutionToEvent(solution, this);
+        RouteChangedEvent event = RouteChangedEventPublisher.solutionToEvent(solution, this);
 
         assertThat(event.vehicleIds()).isEmpty();
         assertThat(event.depotId()).isEmpty();
@@ -77,7 +77,7 @@ class SolutionPublisherTest {
         PlanningVehicle vehicle = testVehicle(vehicleId);
         VehicleRoutingSolution solution = solutionFromVisits(singletonList(vehicle), null, emptyList());
 
-        RouteChangedEvent event = SolutionPublisher.solutionToEvent(solution, this);
+        RouteChangedEvent event = RouteChangedEventPublisher.solutionToEvent(solution, this);
 
         assertThat(event.vehicleIds()).containsExactly(vehicleId);
         assertThat(event.depotId()).isEmpty();
@@ -96,7 +96,7 @@ class SolutionPublisherTest {
                 singletonList(testVisit(visitId))
         );
 
-        RouteChangedEvent event = SolutionPublisher.solutionToEvent(solution, this);
+        RouteChangedEvent event = RouteChangedEventPublisher.solutionToEvent(solution, this);
 
         assertThat(event.vehicleIds()).isEmpty();
         assertThat(event.depotId()).contains(depotId);
@@ -144,7 +144,7 @@ class SolutionPublisherTest {
         solution.setScore(HardSoftLongScore.ofSoft(softScore));
 
         // act
-        RouteChangedEvent event = SolutionPublisher.solutionToEvent(solution, this);
+        RouteChangedEvent event = RouteChangedEventPublisher.solutionToEvent(solution, this);
 
         // assert
         assertThat(event.routes()).hasSameSizeAs(solution.getVehicleList());
@@ -175,7 +175,7 @@ class SolutionPublisherTest {
         );
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> SolutionPublisher.solutionToEvent(solution, this))
+                .isThrownBy(() -> RouteChangedEventPublisher.solutionToEvent(solution, this))
                 .withMessageContaining("Visit");
     }
 
@@ -186,7 +186,7 @@ class SolutionPublisherTest {
         VehicleRoutingSolution solution = solutionFromVisits(singletonList(vehicle), depot, emptyList());
         vehicle.setDepot(null);
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> SolutionPublisher.solutionToEvent(solution, this))
+                .isThrownBy(() -> RouteChangedEventPublisher.solutionToEvent(solution, this))
                 .withMessageContaining("Vehicle");
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImplTest.java
@@ -64,7 +64,7 @@ class RouteOptimizerImplTest {
     @Mock
     private SolverManager solverManager;
     @Mock
-    private SolutionPublisher solutionPublisher;
+    private RouteChangedEventPublisher routeChangedEventPublisher;
     @InjectMocks
     private RouteOptimizerImpl routeOptimizer;
 
@@ -73,7 +73,7 @@ class RouteOptimizerImplTest {
         // arrange
         Long[] vehicleIds = {2L, 3L, 5L, 7L, 11L};
         Arrays.stream(vehicleIds).forEach(vehicleId -> routeOptimizer.addVehicle(testVehicle(vehicleId)));
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         // act
         routeOptimizer.addLocation(location1, matrixRow);
@@ -107,7 +107,7 @@ class RouteOptimizerImplTest {
         assertThat(solutionWithOneVehicle.getVisitList()).isEmpty();
 
         // act 2
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
         routeOptimizer.removeVehicle(vehicle);
 
         // assert 2
@@ -221,7 +221,7 @@ class RouteOptimizerImplTest {
     void solver_should_not_start_nor_stop_when_modifying_location_and_there_are_no_vehicles() {
         // add 2 locations
         routeOptimizer.addLocation(location1, matrixRow);
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
         routeOptimizer.addLocation(location2, matrixRow);
 
         // solving did not start due to missing vehicles
@@ -234,7 +234,7 @@ class RouteOptimizerImplTest {
 
         // add a third location and remove another one
         routeOptimizer.addLocation(location3, matrixRow);
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
         routeOptimizer.removeLocation(location2);
 
         // no interactions with solver (start/stop/problem fact changes) because
@@ -254,7 +254,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addLocation(location1, matrixRow);
         routeOptimizer.addLocation(location2, matrixRow);
         verify(solverManager).startSolver(any(VehicleRoutingSolution.class));
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         routeOptimizer.removeVehicle(vehicle);
         verify(solverManager).stopSolver();
@@ -269,7 +269,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addLocation(location1, matrixRow);
         routeOptimizer.addLocation(location2, matrixRow);
         verify(solverManager).startSolver(any(VehicleRoutingSolution.class));
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         // remove 1 location from running solver
         routeOptimizer.removeLocation(location2);
@@ -302,7 +302,7 @@ class RouteOptimizerImplTest {
         long vehicleId2 = 113;
         routeOptimizer.addVehicle(testVehicle(vehicleId1));
         routeOptimizer.addVehicle(testVehicle(vehicleId2));
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         // when a depot is added
         routeOptimizer.addLocation(location1, matrixRow);
@@ -316,7 +316,7 @@ class RouteOptimizerImplTest {
         assertThat(solution1.getDepotList()).extracting(PlanningDepot::getId).containsExactly(location1.id());
 
         // if we remove the depot
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
         routeOptimizer.removeLocation(location1);
 
         // then published solution's depot list is empty
@@ -413,7 +413,7 @@ class RouteOptimizerImplTest {
         Vehicle vehicle = createVehicle(vehicleId, "", oldCapacity);
         routeOptimizer.addVehicle(vehicle);
         routeOptimizer.addLocation(location1, matrixRow);
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         // change capacity when solver is not running
         routeOptimizer.changeCapacity(createVehicle(vehicleId, "", newCapacity));
@@ -463,7 +463,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addLocation(location2, matrixRow);
         verify(solverManager).startSolver(any(VehicleRoutingSolution.class));
         routeOptimizer.addLocation(location3, matrixRow);
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         routeOptimizer.removeAllLocations();
 
@@ -483,7 +483,7 @@ class RouteOptimizerImplTest {
         routeOptimizer.addLocation(location2, matrixRow);
         verify(solverManager).startSolver(any(VehicleRoutingSolution.class));
         routeOptimizer.addLocation(location3, matrixRow);
-        clearInvocations(solutionPublisher);
+        clearInvocations(routeChangedEventPublisher);
 
         routeOptimizer.removeAllVehicles();
 
@@ -506,7 +506,7 @@ class RouteOptimizerImplTest {
     }
 
     private VehicleRoutingSolution verifyPublishingPreliminarySolution() {
-        verify(solutionPublisher).publishSolution(solutionArgumentCaptor.capture());
+        verify(routeChangedEventPublisher).publishSolution(solutionArgumentCaptor.capture());
         return solutionArgumentCaptor.getValue();
     }
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
@@ -72,7 +72,7 @@ class SolverManagerTest {
     @Mock
     private AsyncListenableTaskExecutor executor;
     @Mock
-    private SolutionPublisher solutionPublisher;
+    private RouteChangedEventPublisher routeChangedEventPublisher;
     @InjectMocks
     private SolverManager solverManager;
 
@@ -102,7 +102,7 @@ class SolverManagerTest {
 
         // assert
         verify(bestSolutionChangedEvent, never()).getNewBestSolution();
-        verify(solutionPublisher, never()).publishSolution(any());
+        verify(routeChangedEventPublisher, never()).publishSolution(any());
     }
 
     @Test
@@ -113,7 +113,7 @@ class SolverManagerTest {
 
         solverManager.bestSolutionChanged(bestSolutionChangedEvent);
 
-        verify(solutionPublisher).publishSolution(solutionArgumentCaptor.capture());
+        verify(routeChangedEventPublisher).publishSolution(solutionArgumentCaptor.capture());
         VehicleRoutingSolution event = solutionArgumentCaptor.getValue();
         assertThat(event).isSameAs(solution);
     }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
@@ -40,7 +40,8 @@ import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
-import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.util.concurrent.ListenableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -64,12 +65,12 @@ class SolverManagerTest {
     @Mock
     private BestSolutionChangedEvent<VehicleRoutingSolution> bestSolutionChangedEvent;
     @Mock
-    private Future<VehicleRoutingSolution> solverFuture;
+    private ListenableFuture<VehicleRoutingSolution> solverFuture;
 
     @Mock
     private Solver<VehicleRoutingSolution> solver;
     @Mock
-    private AsyncTaskExecutor executor;
+    private AsyncListenableTaskExecutor executor;
     @Mock
     private SolutionPublisher solutionPublisher;
     @InjectMocks
@@ -78,7 +79,7 @@ class SolverManagerTest {
     private void returnSolverFutureWhenSolverIsStarted() {
         // always run the runnable submitted to executor (that's what every executor does)
         // we can then verify that solver.solve() has been called
-        when(executor.submit(any(SolverManager.SolvingTask.class))).thenAnswer(
+        when(executor.submitListenable(any(SolverManager.SolvingTask.class))).thenAnswer(
                 answer((Answer1<Future<VehicleRoutingSolution>, SolverManager.SolvingTask>) callable -> {
                     callable.call();
                     return solverFuture;

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableErrorMessageTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/PortableErrorMessageTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.websocket;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.optaweb.vehiclerouting.service.error.ErrorMessage;
+import org.springframework.boot.test.json.JacksonTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PortableErrorMessageTest {
+
+    private JacksonTester<PortableErrorMessage> json;
+
+    @BeforeEach
+    void setUp() {
+        // This initializes the json field
+        JacksonTester.initFields(this, new ObjectMapper());
+    }
+
+    @Test
+    void marshal_to_json() throws IOException {
+        String id = "c670dd37-62fb-4e86-95ed-c1f4953aaeaa";
+        String text = "Error message.\nDetails.";
+        PortableErrorMessage portableErrorMessage = PortableErrorMessage.fromMessage(ErrorMessage.of(id, text));
+        assertThat(json.write(portableErrorMessage)).isStrictlyEqualToJson("portable-error-message.json");
+    }
+
+    @Test
+    void factory_method() {
+        String id = "id";
+        String text = "error";
+        PortableErrorMessage portableErrorMessage = PortableErrorMessage.fromMessage(ErrorMessage.of(id, text));
+        assertThat(portableErrorMessage.getId()).isEqualTo(id);
+        assertThat(portableErrorMessage.getText()).isEqualTo(text);
+    }
+
+    @Test
+    void equals_hashCode_toString() {
+        String id = "1";
+        String text = "error message";
+        ErrorMessage message = ErrorMessage.of(id, text);
+        PortableErrorMessage portableErrorMessage = PortableErrorMessage.fromMessage(message);
+
+        // equals()
+        assertThat(portableErrorMessage).isNotEqualTo(null);
+        assertThat(portableErrorMessage).isNotEqualTo(new PortableErrorMessage("", text));
+        assertThat(portableErrorMessage).isNotEqualTo(new PortableErrorMessage(id, ""));
+        assertThat(portableErrorMessage).isNotEqualTo(message);
+        assertThat(portableErrorMessage).isEqualTo(portableErrorMessage);
+        assertThat(portableErrorMessage).isEqualTo(new PortableErrorMessage(id, text));
+
+        // hasCode()
+        assertThat(portableErrorMessage).hasSameHashCodeAs(new PortableErrorMessage(id, text));
+
+        // toString()
+        assertThat(portableErrorMessage.toString()).contains(id, text);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketControllerTest.java
@@ -34,14 +34,17 @@ import org.optaweb.vehiclerouting.domain.RoutingProblem;
 import org.optaweb.vehiclerouting.domain.Vehicle;
 import org.optaweb.vehiclerouting.domain.VehicleFactory;
 import org.optaweb.vehiclerouting.service.demo.DemoService;
+import org.optaweb.vehiclerouting.service.error.ErrorEvent;
 import org.optaweb.vehiclerouting.service.location.LocationService;
 import org.optaweb.vehiclerouting.service.region.BoundingBox;
 import org.optaweb.vehiclerouting.service.region.RegionService;
 import org.optaweb.vehiclerouting.service.route.RouteListener;
 import org.optaweb.vehiclerouting.service.vehicle.VehicleService;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,13 +56,21 @@ class WebSocketControllerTest {
     @Mock
     private RegionService regionService;
     @Mock
-    private VehicleService vehicleService;
-    @Mock
     private LocationService locationService;
     @Mock
+    private VehicleService vehicleService;
+    @Mock
     private DemoService demoService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
     @InjectMocks
     private WebSocketController webSocketController;
+
+    @Test
+    void exception_handler_should_publish_error_event() {
+        webSocketController.handleException(new Exception());
+        verify(eventPublisher).publishEvent(any(ErrorEvent.class));
+    }
 
     @Test
     void subscribeToRouteTopic() {

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorMessageSenderTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorMessageSenderTest.java
@@ -16,29 +16,25 @@
 
 package org.optaweb.vehiclerouting.plugin.websocket;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.service.error.ErrorMessage;
-import org.optaweb.vehiclerouting.service.error.ErrorPublisher;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Component;
 
-/**
- * Broadcasts application errors to interested clients over WebSocket.
- */
-@Component
-class WebSocketErrorPublisher implements ErrorPublisher {
+import static org.mockito.Mockito.verify;
 
-    static final String TOPIC_ERROR = "/topic/error";
+@ExtendWith(MockitoExtension.class)
+class WebSocketErrorMessageSenderTest {
 
-    private final SimpMessagingTemplate webSocket;
-
-    @Autowired
-    WebSocketErrorPublisher(SimpMessagingTemplate webSocket) {
-        this.webSocket = webSocket;
-    }
-
-    @Override
-    public void publishError(ErrorMessage message) {
-        webSocket.convertAndSend(TOPIC_ERROR, PortableErrorMessage.fromMessage(message));
+    @Test
+    void should_send_consumed_message_over_websocket(@Mock SimpMessagingTemplate webSocket) {
+        ErrorMessage message = ErrorMessage.of("id", "error");
+        new WebSocketErrorMessageSender(webSocket).consumeMessage(message);
+        verify(webSocket).convertAndSend(
+                WebSocketErrorMessageSender.TOPIC_ERROR,
+                PortableErrorMessage.fromMessage(message)
+        );
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisherTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisherTest.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.optaweb.vehiclerouting.service.error.ErrorMessage;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,7 +30,11 @@ class WebSocketErrorPublisherTest {
 
     @Test
     void publish(@Mock SimpMessagingTemplate webSocket) {
-        new WebSocketErrorPublisher(webSocket).publishError("");
-        verify(webSocket).convertAndSend(anyString(), anyString());
+        ErrorMessage message = ErrorMessage.of("id", "error");
+        new WebSocketErrorPublisher(webSocket).publishError(message);
+        verify(webSocket).convertAndSend(
+                WebSocketErrorPublisher.TOPIC_ERROR,
+                PortableErrorMessage.fromMessage(message)
+        );
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisherTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorPublisherTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketErrorPublisherTest {
+
+    @Test
+    void publish(@Mock SimpMessagingTemplate webSocket) {
+        new WebSocketErrorPublisher(webSocket).publishError("");
+        verify(webSocket).convertAndSend(anyString(), anyString());
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
@@ -33,15 +33,16 @@ class ErrorListenerTest {
     private ArgumentCaptor<ErrorMessage> argumentCaptor;
 
     @Test
-    void should_publish_error_event(@Mock ErrorPublisher errorPublisher) {
+    void should_pass_error_message_to_consumer(@Mock ErrorMessageConsumer errorMessageConsumer) {
         // arrange
         String text = "error";
-        ErrorListener errorListener = new ErrorListener(errorPublisher);
+        ErrorListener errorListener = new ErrorListener(errorMessageConsumer);
         // act
         errorListener.onApplicationEvent(new ErrorEvent(this, text));
         // assert
-        verify(errorPublisher).publishError(argumentCaptor.capture());
-        ErrorMessage publishedMessage = argumentCaptor.getValue();
-        assertThat(publishedMessage.text).isEqualTo(text);
+        verify(errorMessageConsumer).consumeMessage(argumentCaptor.capture());
+        ErrorMessage capturedMessage = argumentCaptor.getValue();
+        assertThat(capturedMessage.text).isEqualTo(text);
+        assertThat(capturedMessage.id).isNotNull();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
@@ -18,22 +18,30 @@ package org.optaweb.vehiclerouting.service.error;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class})
 class ErrorListenerTest {
 
+    @Captor
+    private ArgumentCaptor<ErrorMessage> argumentCaptor;
+
     @Test
     void should_publish_error_event(@Mock ErrorPublisher errorPublisher) {
         // arrange
-        String error = "error";
+        String text = "error";
         ErrorListener errorListener = new ErrorListener(errorPublisher);
         // act
-        errorListener.onApplicationEvent(new ErrorEvent(this, error));
+        errorListener.onApplicationEvent(new ErrorEvent(this, text));
         // assert
-        verify(errorPublisher).publishError(error);
+        verify(errorPublisher).publishError(argumentCaptor.capture());
+        ErrorMessage publishedMessage = argumentCaptor.getValue();
+        assertThat(publishedMessage.text).isEqualTo(text);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.service.error;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({MockitoExtension.class})
+class ErrorListenerTest {
+
+    @Test
+    void should_publish_error_event(@Mock ErrorPublisher errorPublisher) {
+        // arrange
+        String error = "error";
+        ErrorListener errorListener = new ErrorListener(errorPublisher);
+        // act
+        errorListener.onApplicationEvent(new ErrorEvent(this, error));
+        // assert
+        verify(errorPublisher).publishError(error);
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
@@ -23,6 +23,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
+import org.optaweb.vehiclerouting.service.error.ErrorEvent;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -42,7 +44,7 @@ class LocationServiceTest {
     @Mock
     private DistanceMatrix distanceMatrix;
     @Mock
-    private DistanceMatrixRow matrixRow;
+    private ApplicationEventPublisher eventPublisher;
     @InjectMocks
     private LocationService locationService;
 
@@ -56,7 +58,7 @@ class LocationServiceTest {
     }
 
     @Test
-    void createLocation() {
+    void createLocation(@Mock DistanceMatrixRow matrixRow) {
         String description = "new location";
         when(repository.createLocation(coordinates, description)).thenReturn(location);
         when(distanceMatrix.addLocation(any())).thenReturn(matrixRow);
@@ -74,7 +76,7 @@ class LocationServiceTest {
     }
 
     @Test
-    void addLocation() {
+    void addLocation(@Mock DistanceMatrixRow matrixRow) {
         when(distanceMatrix.addLocation(any())).thenReturn(matrixRow);
         assertThat(locationService.addLocation(location)).isTrue();
 
@@ -109,6 +111,8 @@ class LocationServiceTest {
 
         assertThat(locationService.createLocation(coordinates, "")).isFalse();
         verifyNoInteractions(optimizer);
+        // publish error event
+        verify(eventPublisher).publishEvent(any(ErrorEvent.class));
         // roll back
         verify(repository).removeLocation(location.id());
     }

--- a/optaweb-vehicle-routing-backend/src/test/resources/org/optaweb/vehiclerouting/plugin/websocket/portable-error-message.json
+++ b/optaweb-vehicle-routing-backend/src/test/resources/org/optaweb/vehiclerouting/plugin/websocket/portable-error-message.json
@@ -1,0 +1,4 @@
+{
+  "id": "c670dd37-62fb-4e86-95ed-c1f4953aaeaa",
+  "text": "Error message.\nDetails."
+}

--- a/optaweb-vehicle-routing-frontend/src/index.tsx
+++ b/optaweb-vehicle-routing-frontend/src/index.tsx
@@ -19,7 +19,6 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import { messageActions } from 'store/message';
 import './index.css';
 import { unregister } from './registerServiceWorker';
 import { configureStore } from './store';
@@ -28,9 +27,6 @@ import App from './ui/App';
 const store = configureStore({
   socketUrl: `${process.env.REACT_APP_BACKEND_URL}/vrp-websocket`,
 });
-
-store.dispatch(messageActions.receiveMessage({ id: '0', text: 'Test message #0' }));
-store.dispatch(messageActions.receiveMessage({ id: '1', text: 'Test message #1' }));
 
 ReactDOM.render(
   <Provider store={store}>

--- a/optaweb-vehicle-routing-frontend/src/index.tsx
+++ b/optaweb-vehicle-routing-frontend/src/index.tsx
@@ -19,6 +19,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
+import { messageActions } from 'store/message';
 import './index.css';
 import { unregister } from './registerServiceWorker';
 import { configureStore } from './store';
@@ -27,6 +28,9 @@ import App from './ui/App';
 const store = configureStore({
   socketUrl: `${process.env.REACT_APP_BACKEND_URL}/vrp-websocket`,
 });
+
+store.dispatch(messageActions.receiveMessage({ id: '0', text: 'Test message #0' }));
+store.dispatch(messageActions.receiveMessage({ id: '1', text: 'Test message #1' }));
 
 ReactDOM.render(
   <Provider store={store}>

--- a/optaweb-vehicle-routing-frontend/src/store/demo/demo.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/demo/demo.test.ts
@@ -83,6 +83,7 @@ const visit3 = {
 
 const state: AppState = {
   connectionStatus: WebSocketConnectionStatus.CLOSED,
+  messages: [],
   serverInfo: {
     boundingBox: null,
     countryCodes: [],

--- a/optaweb-vehicle-routing-frontend/src/store/message/actions.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/actions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionFactory } from '../types';
+import { ActionType, MessagePayload, ReadMessageAction, ReceiveMessageAction } from './types';
+
+export const receiveMessage: ActionFactory<MessagePayload, ReceiveMessageAction> = (payload) => ({
+  type: ActionType.RECEIVE_MESSAGE,
+  ...payload,
+});
+
+export const readMessage: ActionFactory<string, ReadMessageAction> = (id) => ({
+  type: ActionType.READ_MESSAGE,
+  id,
+});

--- a/optaweb-vehicle-routing-frontend/src/store/message/actions.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/actions.ts
@@ -19,7 +19,7 @@ import { ActionType, MessagePayload, ReadMessageAction, ReceiveMessageAction } f
 
 export const receiveMessage: ActionFactory<MessagePayload, ReceiveMessageAction> = (payload) => ({
   type: ActionType.RECEIVE_MESSAGE,
-  ...payload,
+  payload,
 });
 
 export const readMessage: ActionFactory<string, ReadMessageAction> = (id) => ({

--- a/optaweb-vehicle-routing-frontend/src/store/message/index.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as messageActions from './actions';
+import reducer from './reducers';
+import * as messageSelectors from './selectors';
+
+export { messageActions, messageSelectors };
+
+export default reducer;

--- a/optaweb-vehicle-routing-frontend/src/store/message/message.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/message.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Message, MessagePayload } from 'store/message/types';
+import * as actions from './actions';
+import reducer, { messageSelectors } from './index';
+
+const messages: Message[] = [
+  { id: '1', text: '', status: 'read' },
+  { id: '2', text: '', status: 'new' },
+  { id: '3', text: '', status: 'read' },
+  { id: '4', text: '', status: 'new' },
+  { id: '5', text: '', status: 'new' },
+];
+
+describe('Message reducer', () => {
+  it(
+    'should return initial state when previous state is undefined',
+    () => expect(reducer(undefined, actions.readMessage(''))).toEqual([]),
+  );
+
+  it('receiving a message should add it with the status equal to NEW', () => {
+    const message: MessagePayload = { id: 'xy', text: 'message text' };
+    expect(
+      reducer([], actions.receiveMessage(message)),
+    ).toEqual([{ ...message, status: 'new' }]);
+  });
+
+  it('reading a message should update its status to READ', () => {
+    const updatedMessages = [...messages];
+    updatedMessages[1] = { ...messages[1], status: 'read' };
+    expect(
+      reducer(messages, actions.readMessage('2')),
+    ).toEqual(updatedMessages);
+  });
+});
+
+describe('Message selectors', () => {
+  it('select new messages', () => {
+    expect(
+      messageSelectors.getNewMessages(messages),
+    ).toEqual([
+      { id: '2', text: '', status: 'new' },
+      { id: '4', text: '', status: 'new' },
+      { id: '5', text: '', status: 'new' },
+    ]);
+  });
+});

--- a/optaweb-vehicle-routing-frontend/src/store/message/reducers.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/reducers.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionType, Message, MessageAction } from './types';
+
+const messageReducer = (state: Message[] = [], action: MessageAction): Message[] => {
+  switch (action.type) {
+    case ActionType.RECEIVE_MESSAGE: {
+      return [...state, { id: action.id, text: action.text, status: 'new' }];
+    }
+    case ActionType.READ_MESSAGE: {
+      return state.map((message) => (
+        message.id === action.id ? { ...message, status: 'read' } : message
+      ));
+    }
+    default:
+      return state;
+  }
+};
+
+export default messageReducer;

--- a/optaweb-vehicle-routing-frontend/src/store/message/reducers.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/reducers.ts
@@ -19,7 +19,7 @@ import { ActionType, Message, MessageAction } from './types';
 const messageReducer = (state: Message[] = [], action: MessageAction): Message[] => {
   switch (action.type) {
     case ActionType.RECEIVE_MESSAGE: {
-      return [...state, { id: action.id, text: action.text, status: 'new' }];
+      return [...state, { ...action.payload, status: 'new' }];
     }
     case ActionType.READ_MESSAGE: {
       return state.map((message) => (

--- a/optaweb-vehicle-routing-frontend/src/store/message/selectors.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/selectors.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Message } from 'store/message/types';
+
+export const getNewMessages = (messages: Message[]) => messages.filter((message) => message.status === 'new');

--- a/optaweb-vehicle-routing-frontend/src/store/message/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/types.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Action } from 'redux';
+
+export enum ActionType {
+  RECEIVE_MESSAGE = 'RECEIVE_MESSAGE',
+  READ_MESSAGE = 'READ_MESSAGE',
+}
+
+export interface ReceiveMessageAction extends Action<ActionType.RECEIVE_MESSAGE> {
+  readonly id: string;
+  readonly text: string;
+}
+
+export interface ReadMessageAction extends Action<ActionType.READ_MESSAGE> {
+  readonly id: string;
+}
+
+export type MessageAction = ReceiveMessageAction | ReadMessageAction;
+
+export interface MessagePayload {
+  readonly id: string;
+  readonly text: string;
+}
+
+export interface Message extends MessagePayload {
+  readonly status: 'new' | 'read';
+}

--- a/optaweb-vehicle-routing-frontend/src/store/message/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/message/types.ts
@@ -22,8 +22,7 @@ export enum ActionType {
 }
 
 export interface ReceiveMessageAction extends Action<ActionType.RECEIVE_MESSAGE> {
-  readonly id: string;
-  readonly text: string;
+  readonly payload: MessagePayload;
 }
 
 export interface ReadMessageAction extends Action<ActionType.READ_MESSAGE> {

--- a/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/route.test.ts
@@ -167,6 +167,7 @@ const visit5 = {
 
 const state: AppState = {
   connectionStatus: WebSocketConnectionStatus.CLOSED,
+  messages: [],
   serverInfo: {
     boundingBox: null,
     countryCodes: [],

--- a/optaweb-vehicle-routing-frontend/src/store/store.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/store.ts
@@ -23,6 +23,7 @@ import thunk from 'redux-thunk';
 import WebSocketClient from 'websocket/WebSocketClient';
 import clientReducer from './client';
 import demoReducer from './demo';
+import messageReducer from './message';
 import routeReducer from './route';
 import serverInfoReducer from './server';
 import { AppState } from './types';
@@ -47,6 +48,7 @@ export function configureStore(
   // map reducers to state slices
   const rootReducer = combineReducers<AppState>({
     connectionStatus: connectionReducer,
+    messages: messageReducer,
     serverInfo: serverInfoReducer,
     demo: demoReducer,
     plan: routeReducer,

--- a/optaweb-vehicle-routing-frontend/src/store/types.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/types.ts
@@ -16,6 +16,7 @@
 
 import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import { Message } from 'store/message/types';
 import WebSocketClient from 'websocket/WebSocketClient';
 import { UserViewport } from './client/types';
 import { Demo } from './demo/types';
@@ -55,6 +56,7 @@ export type ThunkCommandFactory<V, A extends Action> = V extends void ?
 
 export interface AppState {
   readonly serverInfo: ServerInfo;
+  readonly messages: Message[];
   readonly plan: RoutingPlan;
   readonly connectionStatus: WebSocketConnectionStatus;
   readonly demo: Demo;

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/operations.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/operations.ts
@@ -16,6 +16,8 @@
 
 import { demoOperations } from '../demo';
 import { FinishLoadingAction } from '../demo/types';
+import { messageActions } from '../message';
+import { MessageAction } from '../message/types';
 import { routeOperations } from '../route';
 import { UpdateRouteAction } from '../route/types';
 import { serverOperations } from '../server';
@@ -26,6 +28,7 @@ import { WebSocketAction } from './types';
 
 type ConnectClientThunkAction =
   | WebSocketAction
+  | MessageAction
   | UpdateRouteAction
   | FinishLoadingAction
   | ServerInfoAction;
@@ -43,6 +46,10 @@ export const connectClient: ThunkCommandFactory<void, ConnectClientThunkAction> 
         dispatch(actions.wsConnectionSuccess());
         client.subscribeToServerInfo((serverInfo) => {
           dispatch(serverOperations.serverInfo(serverInfo));
+        });
+        client.subscribeToErrorTopic((message) => {
+          // TODO sync with backend model
+          dispatch(messageActions.receiveMessage({ id: message, text: message }));
         });
         client.subscribeToRoute((plan) => {
           dispatch(routeOperations.updateRoute(plan));

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/operations.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/operations.ts
@@ -47,9 +47,8 @@ export const connectClient: ThunkCommandFactory<void, ConnectClientThunkAction> 
         client.subscribeToServerInfo((serverInfo) => {
           dispatch(serverOperations.serverInfo(serverInfo));
         });
-        client.subscribeToErrorTopic((message) => {
-          // TODO sync with backend model
-          dispatch(messageActions.receiveMessage({ id: message, text: message }));
+        client.subscribeToErrorTopic((errorMessage) => {
+          dispatch(messageActions.receiveMessage(errorMessage));
         });
         client.subscribeToRoute((plan) => {
           dispatch(routeOperations.updateRoute(plan));

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { MessagePayload } from 'store/message/types';
 import { resetViewport } from '../client/actions';
 import { UserViewport } from '../client/types';
 import { demoOperations } from '../demo';
@@ -190,7 +191,7 @@ describe('WebSocket client operations', () => {
       successCallbackCapture = successCallback;
     });
 
-    let errorTopicSubscriptionCallback: (message: string) => void = uninitializedCallbackCapture;
+    let errorTopicSubscriptionCallback: (message: MessagePayload) => void = uninitializedCallbackCapture;
     client.subscribeToErrorTopic = jest.fn().mockImplementation((callback) => {
       errorTopicSubscriptionCallback = callback;
     });
@@ -205,12 +206,12 @@ describe('WebSocket client operations', () => {
     store.clearActions();
 
     // when error message arrives
-    const message = 'error';
+    const message: MessagePayload = { id: '1', text: '2' };
     errorTopicSubscriptionCallback(message);
 
     // action should be dispatched
     expect(store.getActions()).toEqual([
-      receiveMessage({ id: message, text: message }),
+      receiveMessage(message),
     ]);
   });
 });

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
@@ -43,6 +43,7 @@ describe('WebSocket client operations', () => {
   it('should fail connection and reconnect when client crashes', () => {
     const state: AppState = {
       connectionStatus: WebSocketConnectionStatus.CLOSED,
+      messages: [],
       serverInfo: {
         boundingBox: null,
         countryCodes: [],
@@ -108,6 +109,7 @@ describe('WebSocket client operations', () => {
   it('should finish demo loading when all locations are loaded', () => {
     const state: AppState = {
       connectionStatus: WebSocketConnectionStatus.CLOSED,
+      messages: [],
       serverInfo: {
         boundingBox: null,
         countryCodes: [],
@@ -164,6 +166,7 @@ describe('WebSocket client operations', () => {
   it('should dispatch server info and reset viewport', () => {
     const state: AppState = {
       connectionStatus: WebSocketConnectionStatus.CLOSED,
+      messages: [],
       serverInfo: {
         boundingBox: null,
         countryCodes: [],

--- a/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/websocket/websocket.test.ts
@@ -42,22 +42,6 @@ const userViewport: UserViewport = {
 
 describe('WebSocket client operations', () => {
   it('should fail connection and reconnect when client crashes', () => {
-    const state: AppState = {
-      connectionStatus: WebSocketConnectionStatus.CLOSED,
-      messages: [],
-      serverInfo: {
-        boundingBox: null,
-        countryCodes: [],
-        demos: [],
-      },
-      demo: {
-        demoName: null,
-        isLoading: false,
-      },
-      plan: emptyPlan,
-      userViewport,
-    };
-
     let errorCallbackCapture: (err: any) => void = uninitializedCallbackCapture;
     let successCallbackCapture: () => void = uninitializedCallbackCapture;
     let subscribeCallbackCapture: (plan: RoutingPlan) => void = uninitializedCallbackCapture;
@@ -108,9 +92,8 @@ describe('WebSocket client operations', () => {
   });
 
   it('should finish demo loading when all locations are loaded', () => {
-    const state: AppState = {
-      connectionStatus: WebSocketConnectionStatus.CLOSED,
-      messages: [],
+    const stateWithDemo: AppState = {
+      ...state,
       serverInfo: {
         boundingBox: null,
         countryCodes: [],
@@ -123,11 +106,9 @@ describe('WebSocket client operations', () => {
         demoName: 'demo',
         isLoading: true,
       },
-      plan: emptyPlan,
-      userViewport,
     };
 
-    const { store, client } = mockStore(state);
+    const { store, client } = mockStore(stateWithDemo);
 
     let successCallbackCapture: () => void = uninitializedCallbackCapture;
     client.connect = jest.fn().mockImplementation((successCallback) => {
@@ -165,22 +146,6 @@ describe('WebSocket client operations', () => {
   });
 
   it('should dispatch server info and reset viewport', () => {
-    const state: AppState = {
-      connectionStatus: WebSocketConnectionStatus.CLOSED,
-      messages: [],
-      serverInfo: {
-        boundingBox: null,
-        countryCodes: [],
-        demos: [],
-      },
-      demo: {
-        demoName: null,
-        isLoading: false,
-      },
-      plan: emptyPlan,
-      userViewport,
-    };
-
     const { store, client } = mockStore(state);
 
     let successCallbackCapture: () => void = uninitializedCallbackCapture;
@@ -218,22 +183,6 @@ describe('WebSocket client operations', () => {
   });
 
   it('should dispatch errors', () => {
-    const state: AppState = {
-      connectionStatus: WebSocketConnectionStatus.CLOSED,
-      messages: [],
-      serverInfo: {
-        boundingBox: null,
-        countryCodes: [],
-        demos: [],
-      },
-      demo: {
-        demoName: null,
-        isLoading: false,
-      },
-      plan: emptyPlan,
-      userViewport,
-    };
-
     const { store, client } = mockStore(state);
 
     let successCallbackCapture: () => void = uninitializedCallbackCapture;
@@ -329,4 +278,20 @@ const nonEmptyPlan: RoutingPlan = {
   depot: visit1,
   visits: [visit2, visit3, visit4, visit5, visit6],
   routes: [], // not important for the test
+};
+
+const state: AppState = {
+  connectionStatus: WebSocketConnectionStatus.CLOSED,
+  messages: [],
+  serverInfo: {
+    boundingBox: null,
+    countryCodes: [],
+    demos: [],
+  },
+  demo: {
+    demoName: null,
+    isLoading: false,
+  },
+  plan: emptyPlan,
+  userViewport,
 };

--- a/optaweb-vehicle-routing-frontend/src/ui/App.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/App.tsx
@@ -18,6 +18,7 @@ import { Page, PageSection } from '@patternfly/react-core';
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import './App.css';
+import Alerts from 'ui/components/Alerts';
 import Background from './components/Background';
 import { ConnectionManager } from './connection';
 import Header from './header/Header';
@@ -26,6 +27,7 @@ import { Demo, Route as RoutePage, Vehicles, Visits } from './pages';
 const App: React.FC = () => (
   <>
     <ConnectionManager />
+    <Alerts />
     <Page header={<Header />}>
       <Background />
       <PageSection

--- a/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/__snapshots__/App.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`App should render correctly 1`] = `
 <Fragment>
   <Connect(ConnectionManager) />
+  <Connect(Alerts) />
   <Page
     breadcrumb={null}
     className=""

--- a/optaweb-vehicle-routing-frontend/src/ui/components/Alerts.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/Alerts.test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert } from '@patternfly/react-core';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import * as React from 'react';
+import { ReactElement } from 'react';
+import { Alerts, Props } from 'ui/components/Alerts';
+
+describe('Alerts', () => {
+  it('should call readMessage() when alert is closed', () => {
+    const props: Props = {
+      messages: [
+        { id: '1', text: 'msg 1', status: 'new' },
+        { id: '2', text: 'msg 2', status: 'new' },
+      ],
+      readMessage: jest.fn(),
+    };
+    const alerts = shallow(<Alerts {...props} />);
+    expect(toJson(alerts)).toMatchSnapshot();
+
+    (alerts.find(Alert).at(1).prop('action') as ReactElement).props.onClose();
+
+    expect(props.readMessage).toHaveBeenCalledWith('2');
+  });
+
+  it('should not render if there are no messages', () => {
+    const props: Props = {
+      messages: [],
+      readMessage: jest.fn(),
+    };
+    const alerts = shallow(<Alerts {...props} />);
+    expect(toJson(alerts)).toMatchSnapshot();
+  });
+});

--- a/optaweb-vehicle-routing-frontend/src/ui/components/Alerts.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/Alerts.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, AlertActionCloseButton, AlertGroup } from '@patternfly/react-core';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { messageActions, messageSelectors } from 'store/message';
+import { Message } from 'store/message/types';
+import { AppState } from 'store/types';
+
+interface StateProps {
+  messages: Message[];
+}
+
+const mapStateToProps = ({ messages }: AppState): StateProps => ({
+  messages: messageSelectors.getNewMessages(messages),
+});
+
+interface DispatchProps {
+  readMessage: typeof messageActions.readMessage;
+}
+
+const mapDispatchToProps: DispatchProps = {
+  readMessage: messageActions.readMessage,
+};
+
+export type Props = StateProps & DispatchProps;
+
+export const Alerts: React.FC<Props> = ({ messages, readMessage }: Props) => (
+  messages.length > 0 ? (
+    <AlertGroup isToast>
+      {messages
+        .map(({ id, text }) => (
+          <Alert
+            key={id}
+            variant="danger"
+            title="Error"
+            isLiveRegion
+            action={(
+              <AlertActionCloseButton
+                title="Close alert"
+                onClose={() => readMessage(id)}
+              />
+            )}
+          >
+            {text}
+          </Alert>
+        ))}
+    </AlertGroup>
+  ) : null
+);
+
+export default connect(mapStateToProps, mapDispatchToProps)(Alerts);

--- a/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/Alerts.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/Alerts.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alerts should call readMessage() when alert is closed 1`] = `
+<AlertGroup
+  isToast={true}
+>
+  <Component
+    action={
+      <AlertActionCloseButton
+        onClose={[Function]}
+        title="Close alert"
+      />
+    }
+    isLiveRegion={true}
+    key="1"
+    title="Error"
+    variant="danger"
+  >
+    msg 1
+  </Component>
+  <Component
+    action={
+      <AlertActionCloseButton
+        onClose={[Function]}
+        title="Close alert"
+      />
+    }
+    isLiveRegion={true}
+    key="2"
+    title="Error"
+    variant="danger"
+  >
+    msg 2
+  </Component>
+</AlertGroup>
+`;
+
+exports[`Alerts should not render if there are no messages 1`] = `""`;

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
@@ -167,7 +167,7 @@ describe('WebSocketClient', () => {
 
   it('subscribeToErrorTopic() should subscribe with callback', () => {
     const callback = jest.fn();
-    const payload = 'error';
+    const payload = { value: 'test' };
 
     client.connect(onSuccess, onError);
     client.subscribeToErrorTopic(callback);
@@ -175,7 +175,7 @@ describe('WebSocketClient', () => {
     expect(mockClient.subscribe.mock.calls[0][0]).toBe('/topic/error');
     expect(typeof mockClient.subscribe.mock.calls[0][1]).toBe('function');
 
-    mockClient.subscribe.mock.calls[0][1]({ body: payload });
+    mockClient.subscribe.mock.calls[0][1]({ body: JSON.stringify(payload) });
     expect(callback).toHaveBeenCalledWith(payload);
   });
 });

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.test.tsx
@@ -164,4 +164,18 @@ describe('WebSocketClient', () => {
     mockClient.subscribe.mock.calls[0][1]({ body: JSON.stringify(payload) });
     expect(callback).toHaveBeenCalledWith(payload);
   });
+
+  it('subscribeToErrorTopic() should subscribe with callback', () => {
+    const callback = jest.fn();
+    const payload = 'error';
+
+    client.connect(onSuccess, onError);
+    client.subscribeToErrorTopic(callback);
+
+    expect(mockClient.subscribe.mock.calls[0][0]).toBe('/topic/error');
+    expect(typeof mockClient.subscribe.mock.calls[0][1]).toBe('function');
+
+    mockClient.subscribe.mock.calls[0][1]({ body: payload });
+    expect(callback).toHaveBeenCalledWith(payload);
+  });
 });

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
@@ -15,6 +15,7 @@
  */
 
 import SockJS from 'sockjs-client';
+import { MessagePayload } from 'store/message/types';
 import { LatLngWithDescription, RoutingPlan } from 'store/route/types';
 import { ServerInfo } from 'store/server/types';
 import { Client, Frame, over } from 'webstomp-client';
@@ -114,10 +115,10 @@ export default class WebSocketClient {
     }
   }
 
-  subscribeToErrorTopic(subscriptionCallback: (message: string) => any): void {
+  subscribeToErrorTopic(subscriptionCallback: (errorMessage: MessagePayload) => any): void {
     if (this.stompClient) {
       this.stompClient.subscribe('/topic/error', (message) => {
-        subscriptionCallback(message.body);
+        subscriptionCallback(JSON.parse(message.body));
       });
     }
   }

--- a/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
+++ b/optaweb-vehicle-routing-frontend/src/websocket/WebSocketClient.ts
@@ -113,4 +113,12 @@ export default class WebSocketClient {
       });
     }
   }
+
+  subscribeToErrorTopic(subscriptionCallback: (message: string) => any): void {
+    if (this.stompClient) {
+      this.stompClient.subscribe('/topic/error', (message) => {
+        subscriptionCallback(message.body);
+      });
+    }
+  }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-1469

- `ListenableFuture` for `solve()` result allows to act upon an exception or a return immediately (on the solver thread). From main/controller thread perspective, it's still asynchronous but now it's processed immediately by publishing an `ErrorEvent`. Before this, an exception or unexpected return were only detected on the next attempt to submit a PFC or to stop the solver (through `assertSolverIsAlive()`).
- Uncaught exceptions are handled by `WebSocketController` and turned into `ErrorEvent`s.
- An `ErrorEvent` is turned into an `ErrorMessage` by `ErrorListener` (adds a UUID to it) and passed to an `ErrorConsumer` that sends it to `/topic/error`.
- Client picks it up from the topic and adds it to the `AppState` with the message status of `new`.
- An alert is rendered for each `new` message.
- Clicking the close button dispatches a `ReadMessageAction`. The reducer for this action sets the message's status to `read`. Read messages are not displayed but stay in the `AppState`.

## How to test
Click outside the loaded region.

Fixes #84.