### PR TITLE
Change configuration to new OCP 4.5.1 standard

### DIFF
--- a/runOnOpenShift.sh
+++ b/runOnOpenShift.sh
@@ -181,13 +181,13 @@ oc start-build backend --from-dir=${dir_backend} --follow
 # -- new app
 oc new-app backend
 # -- use PostgreSQL secret
-oc set env dc/backend --from=secret/postgresql
+oc set env deployment/backend --from=secret/postgresql
 # -- set the rest of the configuration
-oc set env dc/backend "${dc_backend_env[@]}"
+oc set env deployment/backend "${dc_backend_env[@]}"
 # Remove the default emptyDir volume
-oc set volumes dc/backend --remove --name backend-volume-1
+oc set volumes deployment/backend --remove --name backend-volume-1
 # Replace it with a PVC
-oc set volumes dc/backend --add \
+oc set volumes deployment/backend --add \
     --type pvc \
     --claim-size 1Gi \
     --claim-mode ReadWriteOnce \


### PR DESCRIPTION
Made runOnOpenShift.sh to store configurations
into Deployments instead of DeploymentsConfig

Cherry-pick of #334 
@yurloc 