### PR TITLE
Use static imports for Collectors methods

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/CountryCodeValidator.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/CountryCodeValidator.java
@@ -18,11 +18,12 @@ package org.optaweb.vehiclerouting.domain;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.neovisionaries.i18n.CountryCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Validates ISO 3166-1 alpha-2 country codes.
@@ -45,16 +46,16 @@ public class CountryCodeValidator {
     public static List<String> validate(List<String> countryCodes) {
         List<String> upperCaseCountries = Objects.requireNonNull(countryCodes).stream()
                 .map(String::toUpperCase)
-                .collect(Collectors.toList());
+                .collect(toList());
         List<String> invalidCodes = upperCaseCountries.stream()
                 .filter(s -> CountryCode.getByAlpha2Code(s) == null)
-                .collect(Collectors.toList());
+                .collect(toList());
         if (!invalidCodes.isEmpty()) {
             throw new IllegalArgumentException(
                     "Following elements (" + invalidCodes + ") are not valid ISO 3166-1 alpha-2 country codes"
             );
         }
-        List<String> uniqueCountries = upperCaseCountries.stream().distinct().collect(Collectors.toList());
+        List<String> uniqueCountries = upperCaseCountries.stream().distinct().collect(toList());
         if (uniqueCountries.size() < countryCodes.size()) {
             logger.warn("Duplicate items were removed from {}", countryCodes);
         }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Route.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Route.java
@@ -20,7 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Vehicle's itinerary (sequence of visits) and its depot. This entity cannot exist without the vehicle and the depot
@@ -89,7 +90,7 @@ public class Route {
         return "Route{" +
                 "vehicle=" + vehicle +
                 ", depot=" + depot.id() +
-                ", visits=" + visits.stream().map(Location::id).collect(Collectors.toList()) +
+                ", visits=" + visits.stream().map(Location::id).collect(toList()) +
                 '}';
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RoutingPlan.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/RoutingPlan.java
@@ -22,12 +22,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Route plan for the whole vehicle fleet.
@@ -78,7 +78,7 @@ public class RoutingPlan {
             List<Location> visited = routes.stream()
                     .map(Route::visits)
                     .flatMap(Collection::stream)
-                    .collect(Collectors.toList());
+                    .collect(toList());
             ArrayList<Location> unvisited = new ArrayList<>(visits);
             unvisited.removeAll(visited);
             if (!unvisited.isEmpty()) {
@@ -108,7 +108,7 @@ public class RoutingPlan {
     ) {
         List<Long> vehicleIdsFromRoutes = routes.stream()
                 .map(route -> route.vehicle().id())
-                .collect(Collectors.toList());
+                .collect(toList());
         return cause
                 + ":\n- Vehicles (" + vehicles.size() + "): " + vehicles
                 + "\n- Routes' vehicleIds (" + routes.size() + "): " + vehicleIdsFromRoutes;

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryImpl.java
@@ -18,7 +18,6 @@ package org.optaweb.vehiclerouting.plugin.persistence;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.optaweb.vehiclerouting.domain.Coordinates;
@@ -28,6 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import static java.util.stream.Collectors.toList;
 
 @Component
 class LocationRepositoryImpl implements LocationRepository {
@@ -54,7 +55,7 @@ class LocationRepositoryImpl implements LocationRepository {
     public List<Location> locations() {
         return StreamSupport.stream(repository.findAll().spliterator(), false)
                 .map(LocationRepositoryImpl::toDomain)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     @Override

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/VehicleRepositoryImpl.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/persistence/VehicleRepositoryImpl.java
@@ -18,7 +18,6 @@ package org.optaweb.vehiclerouting.plugin.persistence;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.optaweb.vehiclerouting.domain.Vehicle;
@@ -28,6 +27,8 @@ import org.optaweb.vehiclerouting.service.vehicle.VehicleRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import static java.util.stream.Collectors.toList;
 
 @Component
 public class VehicleRepositoryImpl implements VehicleRepository {
@@ -56,7 +57,7 @@ public class VehicleRepositoryImpl implements VehicleRepository {
     public List<Vehicle> vehicles() {
         return StreamSupport.stream(repository.findAll().spliterator(), false)
                 .map(VehicleRepositoryImpl::toDomain)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     @Override

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteChangedEventPublisher.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/RouteChangedEventPublisher.java
@@ -19,7 +19,6 @@ package org.optaweb.vehiclerouting.plugin.planner;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.optaweb.vehiclerouting.domain.Distance;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningDepot;
@@ -33,6 +32,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Converts planning solution to a {@link RouteChangedEvent} and publishes it so that it can be processed by other
@@ -90,7 +91,7 @@ class RouteChangedEventPublisher {
     private static List<Long> visitIds(VehicleRoutingSolution solution) {
         return solution.getVisitList().stream()
                 .map(visit -> visit.getLocation().getId())
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     /**
@@ -131,7 +132,7 @@ class RouteChangedEventPublisher {
     private static List<Long> vehicleIds(VehicleRoutingSolution solution) {
         return solution.getVehicleList().stream()
                 .map(PlanningVehicle::getId)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     /**

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouter.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouter.java
@@ -17,7 +17,6 @@
 package org.optaweb.vehiclerouting.plugin.routing;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.graphhopper.GHRequest;
@@ -33,6 +32,8 @@ import org.optaweb.vehiclerouting.service.route.Router;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Provides geographical information needed for route optimization.
@@ -58,7 +59,7 @@ class GraphHopperRouter implements Router, DistanceCalculator, Region {
         PointList points = graphHopper.route(ghRequest).getBest().getPoints();
         return StreamSupport.stream(points.spliterator(), false)
                 .map(ghPoint3D -> Coordinates.valueOf(ghPoint3D.lat, ghPoint3D.lon))
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     @Override

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRoutingPlanFactory.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/PortableRoutingPlanFactory.java
@@ -18,12 +18,13 @@ package org.optaweb.vehiclerouting.plugin.websocket;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
 import org.optaweb.vehiclerouting.domain.Vehicle;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Creates instances of {@link PortableRoutingPlan}.
@@ -45,7 +46,7 @@ class PortableRoutingPlanFactory {
                         depot,
                         portableVisits(routeWithTrack.visits()),
                         portableTrack(routeWithTrack.track())))
-                .collect(Collectors.toList());
+                .collect(toList());
         return new PortableRoutingPlan(distance, vehicles, depot, visits, routes);
     }
 
@@ -54,7 +55,7 @@ class PortableRoutingPlanFactory {
         for (List<Coordinates> segment : track) {
             List<PortableCoordinates> portableSegment = segment.stream()
                     .map(PortableCoordinates::fromCoordinates)
-                    .collect(Collectors.toList());
+                    .collect(toList());
             portableTrack.add(portableSegment);
         }
         return portableTrack;
@@ -63,12 +64,12 @@ class PortableRoutingPlanFactory {
     private static List<PortableLocation> portableVisits(List<Location> visits) {
         return visits.stream()
                 .map(PortableLocation::fromLocation)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     private static List<PortableVehicle> portableVehicles(List<Vehicle> vehicles) {
         return vehicles.stream()
                 .map(PortableVehicle::fromVehicle)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketController.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketController.java
@@ -18,7 +18,6 @@ package org.optaweb.vehiclerouting.plugin.websocket;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.RoutingPlan;
@@ -38,6 +37,8 @@ import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.stereotype.Controller;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Handles WebSocket subscriptions and STOMP messages.
@@ -92,7 +93,7 @@ class WebSocketController {
                 .map(routingProblem -> new RoutingProblemInfo(
                         routingProblem.name(),
                         routingProblem.visits().size()))
-                .collect(Collectors.toList());
+                .collect(toList());
         return new ServerInfo(portableBoundingBox, regionService.countryCodes(), demos);
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemConfig.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemConfig.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.optaweb.vehiclerouting.domain.RoutingProblem;
@@ -40,6 +39,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import static java.util.stream.Collectors.toList;
 
 @Configuration
 class RoutingProblemConfig {
@@ -100,7 +101,7 @@ class RoutingProblemConfig {
                     .filter(Objects::nonNull)
                     // TODO make unmarshalling exception checked, catch it and ignore broken files
                     .map(dataSetMarshaller::unmarshal)
-                    .collect(Collectors.toList());
+                    .collect(toList());
         } catch (IOException e) {
             throw new IllegalStateException("Cannot list directory " + dataSetDirPath, e);
         }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemList.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemList.java
@@ -20,10 +20,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.optaweb.vehiclerouting.domain.RoutingProblem;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Utility class that holds a map of routing problem instances and allows to look them up by name.
@@ -35,7 +36,7 @@ class RoutingProblemList {
     RoutingProblemList(List<RoutingProblem> routingProblems) {
         this.routingProblems = Objects.requireNonNull(routingProblems).stream()
                 // TODO use file name as the key (that's more likely to be unique than data set name)
-                .collect(Collectors.toMap(RoutingProblem::name, Function.identity()));
+                .collect(toMap(RoutingProblem::name, identity()));
     }
 
     Collection<RoutingProblem> all() {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshaller.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshaller.java
@@ -19,7 +19,6 @@ package org.optaweb.vehiclerouting.service.demo.dataset;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,6 +29,8 @@ import org.optaweb.vehiclerouting.domain.RoutingProblem;
 import org.optaweb.vehiclerouting.domain.VehicleData;
 import org.optaweb.vehiclerouting.domain.VehicleFactory;
 import org.springframework.stereotype.Component;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Data set marshaller using the YAML format.
@@ -96,11 +97,11 @@ public class DataSetMarshaller {
         dataSet.setDepot(routingProblem.depot().map(DataSetMarshaller::toDataSet).orElse(null));
         dataSet.setVehicles(routingProblem.vehicles().stream()
                 .map(DataSetMarshaller::toDataSet)
-                .collect(Collectors.toList())
+                .collect(toList())
         );
         dataSet.setVisits(routingProblem.visits().stream()
                 .map(DataSetMarshaller::toDataSet)
-                .collect(Collectors.toList())
+                .collect(toList())
         );
         return dataSet;
     }
@@ -120,9 +121,9 @@ public class DataSetMarshaller {
     static RoutingProblem toDomain(DataSet dataSet) {
         return new RoutingProblem(
                 Optional.ofNullable(dataSet.getName()).orElse(""),
-                dataSet.getVehicles().stream().map(DataSetMarshaller::toDomain).collect(Collectors.toList()),
+                dataSet.getVehicles().stream().map(DataSetMarshaller::toDomain).collect(toList()),
                 Optional.ofNullable(dataSet.getDepot()).map(DataSetMarshaller::toDomain).orElse(null),
-                dataSet.getVisits().stream().map(DataSetMarshaller::toDomain).collect(Collectors.toList())
+                dataSet.getVisits().stream().map(DataSetMarshaller::toDomain).collect(toList())
         );
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/RouteListener.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
@@ -37,6 +36,8 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 import static org.optaweb.vehiclerouting.Profiles.NOT_TEST;
 
 /**
@@ -79,9 +80,9 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
             //  be published if revision numbers match) to avoid looking for missing/extra vehicles/visits.
             //  This will also make it possible to get rid of the try-catch approach.
             Map<Long, Vehicle> vehicleMap = event.vehicleIds().stream()
-                    .collect(Collectors.toMap(vehicleId -> vehicleId, this::findVehicleById));
+                    .collect(toMap(vehicleId -> vehicleId, this::findVehicleById));
             Map<Long, Location> visitMap = event.visitIds().stream()
-                    .collect(Collectors.toMap(visitId -> visitId, this::findLocationById));
+                    .collect(toMap(visitId -> visitId, this::findLocationById));
 
             List<RouteWithTrack> routes = event.routes().stream()
                     // list of deep locations
@@ -90,11 +91,11 @@ public class RouteListener implements ApplicationListener<RouteChangedEvent> {
                             findLocationById(shallowRoute.depotId),
                             shallowRoute.visitIds.stream()
                                     .map(visitMap::get)
-                                    .collect(Collectors.toList())
+                                    .collect(toList())
                     ))
                     // add tracks
                     .map(route -> new RouteWithTrack(route, track(route.depot(), route.visits())))
-                    .collect(Collectors.toList());
+                    .collect(toList());
             bestRoutingPlan = new RoutingPlan(
                     event.distance(),
                     new ArrayList<>(vehicleMap.values()),

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/ShallowRoute.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/route/ShallowRoute.java
@@ -20,8 +20,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
 
 // TODO maybe remove this once we fork planning domain from optaplanner-examples
 // because then we can hold a reference to the original location
@@ -65,7 +66,7 @@ public class ShallowRoute {
     public String toString() {
         String route = Stream.concat(Stream.of(depotId), visitIds.stream())
                 .map(Object::toString)
-                .collect(Collectors.joining("->", "[", "]"));
+                .collect(joining("->", "[", "]"));
         return vehicleId + ": " + route;
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/weight/DepotAngleVisitDifficultyWeightFactoryTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/weight/DepotAngleVisitDifficultyWeightFactoryTest.java
@@ -18,7 +18,6 @@ package org.optaweb.vehiclerouting.plugin.planner.weight;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -33,6 +32,7 @@ import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 import org.optaweb.vehiclerouting.plugin.planner.weight.DepotAngleVisitDifficultyWeightFactory.DepotAngleVisitDifficultyWeight;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningLocationFactory.fromDomain;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory.fromLocation;
@@ -101,7 +101,7 @@ class DepotAngleVisitDifficultyWeightFactoryTest {
         // E < NE < N < NW < W < SW < S < SE < E (-π → π)
         assertThat(Stream.of(north1, north2, center1, center2, west, sw1, south1, se1, east1, east2)
                 .map(this::weight)
-                .collect(Collectors.toList())
+                .collect(toList())
         ).isSorted();
 
         assertThat(weight(north1)).isLessThan(weight(north2));


### PR DESCRIPTION
This improves readability because it's shorter and in the context of a stream it's always clear where `toList()` comes from.