### PR TITLE
Make DataSetMarshaller null-safe

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSet.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSet.java
@@ -16,7 +16,6 @@
 
 package org.optaweb.vehiclerouting.service.demo.dataset;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -25,23 +24,27 @@ import java.util.List;
 class DataSet {
 
     private String name;
-    private List<DataSetVehicle> vehicles = new ArrayList<>();
+    private List<DataSetVehicle> vehicles;
     private DataSetLocation depot;
-    private List<DataSetLocation> visits = new ArrayList<>();
+    private List<DataSetLocation> visits;
 
     /**
      * Data set name (a short description).
      *
-     * @return data set name
+     * @return data set name (may be {@code null})
      */
     public String getName() {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     /**
      * Vehicles.
      *
-     * @return vehicles
+     * @return vehicles (may be {@code null})
      */
     public List<DataSetVehicle> getVehicles() {
         return vehicles;
@@ -51,14 +54,10 @@ class DataSet {
         this.vehicles = vehicles;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     /**
      * The depot.
      *
-     * @return the depot
+     * @return the depot (may be {@code null})
      */
     public DataSetLocation getDepot() {
         return depot;
@@ -71,7 +70,7 @@ class DataSet {
     /**
      * Visits.
      *
-     * @return visits
+     * @return visits (may be {@code null})
      */
     public List<DataSetLocation> getVisits() {
         return visits;

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshaller.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshaller.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.optaweb.vehiclerouting.domain.Coordinates;
@@ -122,9 +123,15 @@ public class DataSetMarshaller {
     static RoutingProblem toDomain(DataSet dataSet) {
         return new RoutingProblem(
                 Optional.ofNullable(dataSet.getName()).orElse(""),
-                dataSet.getVehicles().stream().map(DataSetMarshaller::toDomain).collect(toList()),
+                Optional.ofNullable(dataSet.getVehicles()).orElse(Collections.emptyList())
+                        .stream()
+                        .map(DataSetMarshaller::toDomain)
+                        .collect(toList()),
                 Optional.ofNullable(dataSet.getDepot()).map(DataSetMarshaller::toDomain).orElse(null),
-                dataSet.getVisits().stream().map(DataSetMarshaller::toDomain).collect(toList()));
+                Optional.ofNullable(dataSet.getVisits()).orElse(Collections.emptyList())
+                        .stream()
+                        .map(DataSetMarshaller::toDomain)
+                        .collect(toList()));
     }
 
     static LocationData toDomain(DataSetLocation dataSetLocation) {


### PR DESCRIPTION
When a YAML data set contains:

```
vehicles:
```

meaning the attribute is present without a value, the corresponding Java
field is set to null regardless the initial value of the field. We can't
control this. The solution is to make the code working with DataSet
null-safe.
