### PR TITLE
BXMSPROD-1004 Switch OptaWeb releases from master to 7.x branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
         uses: kiegroup/github-action-build-chain@v1.4
         with:
           parent-dependencies: 'optaweb-employee-rostering'
-          child-dependencies: 'kie-wb-distributions'
+          child-dependencies: 'kie-wb-distributions@7.x:master'
           build-command: |
             mvn -e -nsu -Dfull -Pwildfly install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
           build-command-upstream: |


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1004

https://github.com/kiegroup/optaweb-vehicle-routing/pull/368
https://github.com/kiegroup/optaweb-employee-rostering/pull/499
https://github.com/kiegroup/kie-docs/pull/2850
https://github.com/kiegroup/kie-wb-distributions/pull/1063