### PR TITLE
Upgrade go-offline-maven-plugin to 1.2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
     - "$HOME/optaweb-vehicle-routing/optaweb-vehicle-routing-frontend/node"
 # Download dependencies in quiet mode to avoid exceeding maximum log length.
 install: >
-  mvn de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies
+  mvn de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies
   -DfailOnErrors -DdownloadSources=false
   -Prun-code-coverage,sonarcloud-analysis
   --quiet


### PR DESCRIPTION
The following error blocks #384: 
```
$ mvn de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies -DfailOnErrors -DdownloadSources=false -Prun-code-coverage,sonarcloud-analysis --quiet
[ERROR] Error downloading dependencies for project
[ERROR] Could not find artifact org.optaweb.vehiclerouting:optaweb-vehicle-routing-docs:zip:8.0.0-SNAPSHOT in sonatype-snapshots (https://oss.sonatype.org/content/repositories/snapshots/)
```
The plugin tries to download the docs module that hasn't been released yet. It's a bug in the plugin (qaware/go-offline-maven-plugin/issues/16) which has been fixed in 1.2.4.
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
