### PR TITLE
Drop OpenJDK 8, add OpenJDK 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ git:
 language: java
 jobs:
   include:
-    - jdk: openjdk8
+    - jdk: openjdk11
+    - jdk: openjdk15
       env:
         - SONAR_SKIP=true
-    - jdk: openjdk11
 cache:
   directories:
     - "$HOME/.m2/repository"


### PR DESCRIPTION
### Description
When #384 is merged it will no longer be possible to build the project on Java 8.

=> Therefore,
- Replacing Java 8 with Java 11,
- and replacing Java 11 with the latest - Java 15.

### JIRA
None.

### Referenced pull requests
None.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
