### PR TITLE
Fix SonarCloud coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - '! grep "\"resolved\".*\.redhat\.com" optaweb-vehicle-routing-frontend/package-lock.json'
 script:
   - mvn clean install -Prun-code-coverage,integration-tests --show-version
-  - mvn sonar:sonar -Psonarcloud-analysis -Dsonar.skip=$SONAR_SKIP
+  - mvn validate -Psonarcloud-analysis -Dsonar.skip=$SONAR_SKIP
   # Check that Git working tree is clean after running npm install via a frontend-maven-plugin.
   # The `git` command returns 1 and fails the build if there are any uncommitted changes.
   - git diff HEAD --exit-code

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -286,26 +286,6 @@
     </profile>
 
     <profile>
-      <id>run-code-coverage</id> <!-- Do not change. This exact ID is used in Jenkins jobs. -->
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <!-- Append jacoco.agent.argLine property populated by JaCoCo's prepare-agent goal. -->
-              <argLine>@{jacoco.agent.argLine}</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>cypress</id>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,6 @@
     <formatter.skip>false</formatter.skip>
     <formatter.goal>format</formatter.goal>
     <impsort.goal>sort</impsort.goal>
-    <!-- Define JaCoCo agent argLine property to avoid Surefire failure when JaCoCo is not enabled. -->
-    <jacoco.agent.argLine/>
     <version.frontend-maven-plugin>1.10.0</version.frontend-maven-plugin>
     <version.com.h2database>1.4.199</version.com.h2database>
     <version.com.graphhopper>0.13.0-pre13</version.com.graphhopper>
@@ -123,27 +121,6 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${version.org.springframework.boot}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>jacoco-prepare-agent</id>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-              <configuration>
-                <propertyName>jacoco.agent.argLine</propertyName>
-              </configuration>
-            </execution>
-            <execution>
-              <id>jacoco-generate-report</id>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
Remove all JaCoCo configuration to avoid interference with
optaplanner-build-parent. As a bonus, we get multi-module coverage
report and a slight coverage percentage increase (Spring *Properties and
*Config classes get better coverage for some reason).

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
