### PR TITLE
Clean up 8.x

### DIFF
--- a/optaweb-vehicle-routing-backend/Dockerfile
+++ b/optaweb-vehicle-routing-backend/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM adoptopenjdk/openjdk8:ubi-minimal-jre
+FROM docker.io/adoptopenjdk/openjdk15:ubi-minimal-jre
 ENV APP_ROUTING_ENGINE air
 COPY target/*-exec.jar /opt/app/optaweb-vehicle-routing.jar
 WORKDIR /opt/app

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -90,13 +90,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- Needed because kie-parent depends on hamcrest-core. -->
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -214,9 +207,9 @@
               </dependency>
             </dependencies>
             <!--
-              kie-parent contains Pitest configuration that doesn't work well for this project and it's not possible
-              to change it without a complete override (combine.self="override"), for example excludedClasses,
-              timeoutConstant.
+              optaplanner-build-parent contains Pitest configuration that doesn't work well for this project
+              and it's not possible to change it without a complete override (combine.self="override"),
+              for example excludedClasses, timeoutConstant.
             -->
             <configuration>
               <reportsDirectory>local/pit-reports</reportsDirectory>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -141,17 +141,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- Skip Checkstyle execution inherited from kie-parent. -->
-            <id>validate</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -156,9 +156,8 @@
         <configuration>
           <compilerArgs>
             <!--
-              Visit https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html
-              to learn more about javac warnings.
-             -->
+              Visit https://docs.oracle.com/en/java/javase/11/tools/javac.html to learn more about javac warnings.
+            -->
             <arg>-Xlint:all</arg>
             <arg>-Xlint:-processing</arg>
             <arg>-Xlint:-serial</arg>

--- a/optaweb-vehicle-routing-distribution/src/main/assembly/assembly-optaweb-vehicle-routing.xml
+++ b/optaweb-vehicle-routing-distribution/src/main/assembly/assembly-optaweb-vehicle-routing.xml
@@ -39,8 +39,13 @@
       <directory>..</directory>
       <outputDirectory>sources</outputDirectory>
       <excludes>
+        <!-- Maven build output -->
         <exclude>**/target/**</exclude>
+        <!-- Local, Git-ignored files -->
         <exclude>**/local/**</exclude>
+        <!-- Maven profiler reports -->
+        <exclude>**/.profiler/**</exclude>
+        <!-- IDE configs -->
         <exclude>**/.project</exclude>
         <exclude>**/.idea/**</exclude>
         <exclude>**/*.ipr</exclude>
@@ -48,8 +53,11 @@
         <exclude>**/*.iml</exclude>
         <exclude>**/nbproject/**</exclude>
         <exclude>**/.vscode/**</exclude>
+        <!-- OS-specific garbage -->
         <exclude>**/.DS_Store</exclude>
+        <!-- Git repository -->
         <exclude>.git/**</exclude>
+        <!-- Front end module build output, dependencies, reports -->
         <exclude>optaweb-vehicle-routing-frontend/.scannerwork/**</exclude>
         <exclude>optaweb-vehicle-routing-frontend/build/**</exclude>
         <exclude>optaweb-vehicle-routing-frontend/coverage/**</exclude>

--- a/optaweb-vehicle-routing-docs/src/main/asciidoc/development-guide.adoc
+++ b/optaweb-vehicle-routing-docs/src/main/asciidoc/development-guide.adoc
@@ -57,7 +57,7 @@ To learn more about the back end code architecture, see <<appendix-backend-archi
 === Running the back end using Spring Boot Maven plugin
 
 .Prerequisites
-- Java 8 or higher is <<quickstart#install-java,installed>>.
+- Java 11 or higher is <<quickstart#install-java,installed>>.
 - The data directory is set up.
 - An OSM file is downloaded.
 // TODO application-local.properties

--- a/optaweb-vehicle-routing-docs/src/main/asciidoc/quickstart.adoc
+++ b/optaweb-vehicle-routing-docs/src/main/asciidoc/quickstart.adoc
@@ -13,9 +13,9 @@ You will use a Bash script to run the binary without having to build the project
 //to display map tiles and provide search results.
 
 [[install-java]]
-== Install Java 8 or higher
+== Install Java 11 or higher
 
-*Java SE 8 or higher* must be installed on your system before you can use OptaWeb Vehicle Routing.
+*Java SE 11 or higher* must be installed on your system before you can use OptaWeb Vehicle Routing.
 
 NOTE: It is recommended that you install Java SE Development Kit (JDK) because it is necessary in order to build OptaWeb Vehicle Routing from the source.
 However, if you have a binary distribution of OptaWeb Vehicle Routing, you only need the Java SE Runtime Environment (JRE).
@@ -28,12 +28,12 @@ However, if you have a binary distribution of OptaWeb Vehicle Routing, you only 
 java -version
 ----
 
-. If necessary, install OpenJDK 8.
-* To install OpenJDK 8 on Fedora, enter the following command:
+. If necessary, install OpenJDK 11.
+* To install OpenJDK 11 on Fedora, enter the following command:
 +
 [source,shell]
 ----
-sudo dnf install java-1.8.0-openjdk-devel
+sudo dnf install java-11-openjdk-devel
 ----
 
 * To install OpenJDK on other platforms, follow instructions at https://openjdk.java.net/install/.
@@ -71,7 +71,7 @@ NOTE: If Bash is not available on your system, continue to <<run-noscript#run-no
 .Prerequisites
 * Internet access is available.
 When OptaWeb Vehicle Routing runs it uses third-party public services such as link:https://www.openstreetmap.org/about[OpenStreetMap] to display map tiles and provide search results.
-* Java 8 or higher is installed.
+* Java 11 or higher is installed.
 * OptaWeb Vehicle Routing distribution archive is downloaded and extracted.
 
 .Procedure

--- a/optaweb-vehicle-routing-docs/src/main/asciidoc/run-locally.adoc
+++ b/optaweb-vehicle-routing-docs/src/main/asciidoc/run-locally.adoc
@@ -20,7 +20,7 @@ To use the quickstart mode, run the script with no arguments.
 .Prerequisites
 * `optaweb-vehicle-routing` repository is cloned on your computer.
 * Internet access is available.
-* Java 8 or higher is installed.
+* Java 11 or higher is installed.
 
 .Procedure
 . Change directory to the project root.

--- a/optaweb-vehicle-routing-docs/src/main/asciidoc/run-noscript.adoc
+++ b/optaweb-vehicle-routing-docs/src/main/asciidoc/run-noscript.adoc
@@ -57,7 +57,7 @@ $HOME/{data-dir-name}
 .Prerequisites
 * Internet access is available.
 When OptaWeb Vehicle Routing runs it uses third-party public services such as link:https://www.openstreetmap.org/about[OpenStreetMap] to display map tiles and provide search results.
-* Java 8 or higher is installed.
+* Java 11 or higher is installed.
 * The data directory is created at `$HOME/{data-dir-name}`.
 * A subdirectory called `openstreetmap` with at least one OSM file exists.
 * A country code to use in search queries is identified.

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
     <version.node>v12.16.2</version.node>
     <version.npm>6.14.4</version.npm>
-    <version.org.mockito>3.1.0</version.org.mockito>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Cleans up POMs, documentation and Dockerfiles after bumping to OptaPlanner 8.0 and replacing `kie-parent` with `optaplanner-build-parent` in #384.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->


<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->


<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
