### PR TITLE
Nicer polylines

### DIFF
--- a/optaweb-vehicle-routing-frontend/src/ui/components/RouteMap.tsx
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/RouteMap.tsx
@@ -99,6 +99,9 @@ const RouteMap: React.FC<Props> = ({
           positions={route.track}
           fill={false}
           color={color(index)}
+          smoothFactor={3}
+          weight={9}
+          opacity={0.6666}
         />
       ))}
       {bounds && (

--- a/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/RouteMap.test.tsx.snap
+++ b/optaweb-vehicle-routing-frontend/src/ui/components/__snapshots__/RouteMap.test.tsx.snap
@@ -145,6 +145,7 @@ exports[`Route Map should pan and zoom to show bounding box if viewport is not d
     color="deepskyblue"
     fill={false}
     key="0"
+    opacity={0.6666}
     positions={
       Array [
         Array [
@@ -157,6 +158,8 @@ exports[`Route Map should pan and zoom to show bounding box if viewport is not d
         ],
       ]
     }
+    smoothFactor={3}
+    weight={9}
   />
   <ForwardRef(Leaflet(Rectangle))
     bounds={
@@ -224,7 +227,10 @@ exports[`Route Map should show the whole world when bounding box is null 1`] = `
     color="deepskyblue"
     fill={false}
     key="0"
+    opacity={0.6666}
     positions={Array []}
+    smoothFactor={3}
+    weight={9}
   />
 </Map>
 `;


### PR DESCRIPTION
### Description
- Thicker lines make it easier to discern a route from a road when the colors are similar.
- Transparency helps to see where multiple routes overlap.
- [Smoothness factor](https://leafletjs.com/reference-1.7.1.html#polyline-smoothfactor) sacrifices accuracy for performance and smoother look.

### Before

![OptaWeb Vehicle Routing - thin](https://user-images.githubusercontent.com/673386/98802569-c4394c00-2413-11eb-9858-2a2703e3d6d6.png)

### After

![OptaWeb Vehicle Routing - thick](https://user-images.githubusercontent.com/673386/98802574-c9969680-2413-11eb-8737-6d1b62a7a98f.png)

### JIRA
None.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
