### PR TITLE
Remove maven.compiler.release which is inherited from optaplanner-build-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,10 @@
   </modules>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
-    <version.frontend-maven-plugin>1.10.0</version.frontend-maven-plugin>
-    <version.com.h2database>1.4.199</version.com.h2database>
     <version.com.graphhopper>0.13.0-pre13</version.com.graphhopper>
+    <version.com.h2database>1.4.199</version.com.h2database>
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
+    <version.frontend-maven-plugin>1.10.0</version.frontend-maven-plugin>
     <version.node>v12.16.2</version.node>
     <version.npm>6.14.4</version.npm>
   </properties>


### PR DESCRIPTION
Currently it's wrongly detected as 8 during Sonar Scanner execution:

[INFO] Configured Java source version (sonar.java.source): 8

According to documentation [1], sonar.java.source affects rule
activation. Using a lower version (8) might cause some Java 11 rules no
being activated.

[1] https://docs.sonarqube.org/latest/analysis/languages/java/


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
