### PR TITLE
Prepare for Spring Boot upgrade (add validation dependencies, set JPA bootstrap mode)

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -57,6 +57,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-websocket</artifactId>
     </dependency>
+    <!-- For validation annotations (@NotNull) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-spring-boot-starter</artifactId>

--- a/optaweb-vehicle-routing-backend/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application.properties
@@ -38,6 +38,10 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 
+# Turn off deferred bootstrap mode. This is a workaround for https://github.com/spring-projects/spring-boot/issues/24249.
+# What is JPA repository bootstrap mode: https://docs.spring.io/spring-data/jpa/docs/2.4.3/reference/html/#jpa.bootstrap-mode.
+spring.data.jpa.repositories.bootstrap-mode=default
+
 # H2
 # You can connect to H2 console and examine DB contents at http://localhost:8080/h2-console/.
 # Don't forget to enter "JDBC URL: jdbc:h2:file:./local/db/vrp".


### PR DESCRIPTION
It was used to be brought by one of the Spring Boot Starters but it
disappeared during upgrade to Spring Boot 2.3.4.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
