### PR TITLE
PLANNER-2318: Move SonarCloud analysis from Travis to Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ jobs:
   include:
     - jdk: openjdk11
     - jdk: openjdk15
-      env:
-        - SONAR_SKIP=true
 cache:
   directories:
     - "$HOME/.m2/repository"
     - "$HOME/.npm"
-    - "$HOME/.sonar/cache"
-    - "$HOME/.sonar/native-sonar-scanner"
     - "$HOME/optaweb-vehicle-routing/optaweb-vehicle-routing-frontend/node"
 before_install:
   - nvm install --lts
@@ -21,14 +17,12 @@ before_install:
 install: >
   mvn de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies
   -DfailOnErrors -DdownloadSources=false
-  -Prun-code-coverage,sonarcloud-analysis
   --quiet
 before_script:
   # Fail the build if the Red Hat package registry is referenced from package-lock.json.
   - '! grep "\"resolved\".*\.redhat\.com" optaweb-vehicle-routing-frontend/package-lock.json'
 script:
-  - mvn clean install -Prun-code-coverage,integration-tests --show-version
-  - mvn validate -Psonarcloud-analysis -Dsonar.skip=$SONAR_SKIP
+  - mvn clean install integration-tests --show-version
   # Check that Git working tree is clean after running npm install via a frontend-maven-plugin.
   # The `git` command returns 1 and fails the build if there are any uncommitted changes.
   - git diff HEAD --exit-code

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,19 +29,18 @@ pipeline {
                 }
             }
         }
-        stage('Build Optaweb Vehicle Routing') {
+        stage('Build OptaWeb Vehicle Routing') {
             steps {
                 mavenCleanInstall("optaweb-vehicle-routing", false, ["run-code-coverage", "integration-tests"])
             }
         }
-        /* Uncomment to switch SonarCloud analysis from Travis to this pipeline.
-        stage('Analyze Optaweb Vehicle Routing by SonarCloud') {
+        stage('Analyze OptaWeb Vehicle Routing by SonarCloud') {
             steps {
                 withCredentials([string(credentialsId: 'SONARCLOUD_TOKEN', variable: 'SONARCLOUD_TOKEN')]) {
-                    runMaven("sonar:sonar", "optaweb-vehicle-routing", true, ["sonarcloud-analysis"], "-e -nsu")
+                    runMaven("validate", "optaweb-vehicle-routing", true, ["sonarcloud-analysis"], "-e -nsu")
                 }
             }
-        */
+        }
     }
     post {
         always {

--- a/optaweb-vehicle-routing-frontend/.gitignore
+++ b/optaweb-vehicle-routing-frontend/.gitignore
@@ -24,7 +24,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# SonarQube Scanner working dir
-# Runs on Travis but can be run locally with npx (see travis-sonarcloud.sh)
-/.scannerwork

--- a/pom.xml
+++ b/pom.xml
@@ -120,64 +120,6 @@
     </pluginManagement>
   </build>
 
-  <profiles>
-    <!-- Skip Sonar plugin execution if SONARCLOUD_TOKEN is not set. -->
-    <profile>
-      <id>skipSonar</id>
-      <activation>
-        <property>
-          <name>!env.SONARCLOUD_TOKEN</name>
-        </property>
-      </activation>
-      <properties>
-        <sonar.skip>true</sonar.skip>
-      </properties>
-    </profile>
-    <profile>
-      <id>pullRequestAnalysis-Travis</id>
-      <!--
-        Only set sonar.pullrequest properties when the Travis build is triggered by a PR.
-        When the build is triggered by push to a branch or by cron, the consumed env.TRAVIS properties are empty,
-        resulting in invalid sonar.pullrequest properties and the Sonar plugin would fail.
-      -->
-      <activation>
-        <property>
-          <name>env.TRAVIS_EVENT_TYPE</name>
-          <value>pull_request</value>
-        </property>
-      </activation>
-      <!--
-        See https://docs.travis-ci.com/user/environment-variables/ for list of Travis environment variables.
-        See https://docs.sonarqube.org/latest/analysis/pull-request/ for properties required by Sonar for PR analysis.
-      -->
-      <properties>
-        <!--suppress UnresolvedMavenProperty -->
-        <sonar.pullrequest.branch>${env.TRAVIS_PULL_REQUEST_BRANCH}</sonar.pullrequest.branch>
-        <!--suppress UnresolvedMavenProperty -->
-        <sonar.pullrequest.key>${env.TRAVIS_PULL_REQUEST}</sonar.pullrequest.key>
-        <!--suppress UnresolvedMavenProperty -->
-        <sonar.pullrequest.base>${env.TRAVIS_BRANCH}</sonar.pullrequest.base>
-      </properties>
-    </profile>
-    <profile>
-      <id>branchAnalysis-Travis</id>
-      <activation>
-        <property>
-          <name>env.TRAVIS_EVENT_TYPE</name>
-          <value>!pull_request</value>
-        </property>
-      </activation>
-      <!--
-        See https://docs.travis-ci.com/user/environment-variables/ for list of Travis environment variables.
-        See https://docs.sonarqube.org/latest/branches/overview/ for properties required by Sonar for branch analysis.
-      -->
-      <properties>
-        <!--suppress UnresolvedMavenProperty -->
-        <sonar.branch.name>${env.TRAVIS_BRANCH}</sonar.branch.name>
-      </properties>
-    </profile>
-  </profiles>
-
   <repositories>
     <!-- Bootstrap repository to locate the parent POM when it has not been built locally. -->
     <repository>


### PR DESCRIPTION
- Jenkins has a more secure way of sharing the SonarCloud token.
- Travis changes pricing model. I'm currently unable to run builds on
  Travis CI.

Related reading:
- https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
- https://travis-ci.community/t/org-com-migration-unexpectedly-comes-with-a-plan-change-for-oss-what-exactly-is-the-new-deal/10567
- https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2318

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
