### PR TITLE
Define automatic module name

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -32,7 +32,7 @@
   <name>OptaWeb Vehicle Routing Backend</name>
 
   <properties>
-    <java.module.name>org.optaweb.vehiclerouting</java.module.name>
+    <java.module.name>org.optaweb.vehiclerouting.backend</java.module.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -32,6 +32,7 @@
   <name>OptaWeb Vehicle Routing Backend</name>
 
   <properties>
+    <java.module.name>org.optaweb.vehiclerouting</java.module.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -36,6 +36,7 @@
     <!-- Override to run with Podman. -->
     <container.runtime>docker</container.runtime>
     <frontend.project.name>optaweb-vehicle-routing-frontend</frontend.project.name>
+    <java.module.name>org.optaweb.vehiclerouting</java.module.name>
     <test.osm.file>planet_12.032,53.0171_12.1024,53.0491.osm.pbf</test.osm.file>
     <version.cypress.docker>4.12.1</version.cypress.docker>
   </properties>


### PR DESCRIPTION
Fixes the build broken by https://github.com/kiegroup/optaplanner/pull/1141

`Error assembling JAR: Invalid automatic module name: ''`

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
