### PR TITLE
Fix process spawn by exec-maven-plugin

### DIFF
--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -166,7 +166,7 @@
                   <goal>start</goal>
                 </goals>
                 <configuration>
-                  <name>Run application</name>
+                  <name>VRP Backend</name>
                   <healthcheckUrl>http://localhost:${application.port}</healthcheckUrl>
                   <workingDir>${project.basedir}</workingDir>
                   <processLogFile>${project.build.directory}/${project.artifactId}.log</processLogFile>
@@ -184,34 +184,21 @@
                   </arguments>
                 </configuration>
               </execution>
-              <!-- Kill all running processes. -->
-              <execution>
-                <id>stop-running-processes</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>stop-all</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <!--
             Run Cypress tests in a docker container.
             See https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command.
            -->
-          <plugin>
-            <artifactId>exec-maven-plugin</artifactId>
-            <groupId>org.codehaus.mojo</groupId>
-            <executions>
               <execution>
                 <id>run-cypress-tests</id>
                 <phase>integration-test</phase>
                 <goals>
-                  <goal>exec</goal>
+                  <goal>start</goal>
                 </goals>
                 <configuration>
-                  <executable>${container.runtime}</executable>
-                  <workingDirectory>${project.parent.basedir}/${frontend.project.name}</workingDirectory>
+                  <name>Dockerized Cypress</name>
+                  <workingDir>${project.parent.basedir}/${frontend.project.name}</workingDir>
                   <arguments>
+                    <argument>${container.runtime}</argument>
                     <argument>run</argument>
                     <argument>--network=host</argument> <!-- Cypress accesses UI running on the host. -->
                     <argument>--volume</argument>
@@ -228,6 +215,14 @@
                     <argument>baseUrl=http://localhost:${application.port}</argument>
                   </arguments>
                 </configuration>
+              </execution>
+              <!-- Kill all running processes. -->
+              <execution>
+                <id>stop-running-processes</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop-all</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Exec plugin not releasing the process and blocks to proceed with other mvn commands.
So when Jenkins run mvn deploy after test execution ends it got some resource files locked and unable to mvn clean it.

Details on the issue could be found here: https://stackoverflow.com/questions/9937402/process-spawned-by-exec-maven-plugin-blocks-the-maven-process

I use https://github.com/bazaarvoice/maven-process-plugin for both: preparation BE and running cypress tests. So far so good it is working see green deployment here: https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/custom%2Fadupliak%2Fquickstarts-release-pipeline%2Foptaplanner-deploy/detail/optaplanner-deploy/63/pipeline


<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

Similar change as in https://github.com/kiegroup/optaplanner/pull/1136

-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
