### PR TITLE
BXMSPROD-1228 .mvn/extensions.xml takari backported

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,11 +59,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
-      - name: Install takari
-        run: |
-          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar
-          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar
-          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>fr.jcgay.maven</groupId>
-    <artifactId>maven-profiler</artifactId>
-    <version>3.0</version>
+    <groupId>io.takari.aether</groupId>
+    <artifactId>takari-local-repository</artifactId>
+    <version>0.11.3</version>
+  </extension>
+  <extension>
+    <groupId>io.takari</groupId>
+    <artifactId>takari-filemanager</artifactId>
+    <version>0.8.3</version>
+  </extension>
+  <extension>
+    <groupId>io.takari.maven</groupId>
+    <artifactId>takari-smart-builder</artifactId>
+     <version>0.6.1</version>
   </extension>
 </extensions>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1228

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1601
https://github.com/kiegroup/kie-soup/pull/184
https://github.com/kiegroup/droolsjbpm-knowledge/pull/507
https://github.com/kiegroup/drools/pull/3417
https://github.com/kiegroup/optaplanner/pull/1195
https://github.com/kiegroup/lienzo-core/pull/143
https://github.com/kiegroup/lienzo-tests/pull/115
https://github.com/kiegroup/appformer/pull/1113
https://github.com/kiegroup/kie-uberfire-extensions/pull/113
https://github.com/kiegroup/jbpm/pull/1882
https://github.com/kiegroup/kie-jpmml-integration/pull/51
https://github.com/kiegroup/droolsjbpm-integration/pull/2411
https://github.com/kiegroup/kie-wb-playground/pull/105
https://github.com/kiegroup/kie-wb-common/pull/3584
https://github.com/kiegroup/drools-wb/pull/1468
https://github.com/kiegroup/jbpm-designer/pull/900
https://github.com/kiegroup/jbpm-work-items/pull/177
https://github.com/kiegroup/jbpm-wb/pull/1483
https://github.com/kiegroup/optaplanner-wb/pull/390
https://github.com/kiegroup/kie-wb-distributions/pull/1090
https://github.com/kiegroup/openshift-drools-hacep/pull/107
https://github.com/kiegroup/optaweb-employee-rostering/pull/581
https://github.com/kiegroup/optaweb-vehicle-routing/pull/439
https://github.com/kiegroup/droolsjbpm-tools/pull/126