### PR TITLE
PLANNER-2360: Move Hasselt out of city center to fix Belgium data set

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/resources/org/optaweb/vehiclerouting/service/demo/belgium-cities.yaml
+++ b/optaweb-vehicle-routing-backend/src/main/resources/org/optaweb/vehiclerouting/service/demo/belgium-cities.yaml
@@ -56,7 +56,7 @@ visits:
     lng: 4.233333
   - label: "Hasselt"
     lat: 50.93
-    lng: 5.3375
+    lng: 5.34
   - label: "Ixelles"
     lat: 50.833333
     lng: 4.366667


### PR DESCRIPTION
The Belgium data set became broken some time around March 2020.
I thought the Hasselt location became inaccessible because of movement
restrictions introduced in response to the pandemic. In any case, the
location is still inacessible and we need the built-in data set to work
out of the box. Therefore, making Hasselt accessible by moving it
further from the city center.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2360
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
