### PR TITLE
Disable Cypress tests on the standalone module

### DIFF
--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -121,11 +121,11 @@
 
   <profiles>
     <profile>
-      <id>integration-tests</id>
+      <id>FIXME-integration-tests</id>
       <activation>
         <property>
           <name>integration-tests</name>
-          <value>true</value>
+          <value>FIXME-true</value>
         </property>
       </activation>
       <build>


### PR DESCRIPTION
The tests are currently unstable or broken. The fix may require
a non-trivial effort. To make the CI stable, let's disable the tests for
now.


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
