### PR TITLE
Allow empty archive on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
             junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
 
             echo 'Archiving screenshots and videos ...'
-            archiveArtifacts artifacts: '**/cypress/screenshots/**, **/cypress/videos/**'
+            archiveArtifacts allowEmptyArchive: true, artifacts: '**/cypress/screenshots/**, **/cypress/videos/**'
 
             cleanWs()
         }


### PR DESCRIPTION
Fix Jenkins build that started failing after integration tests were disabled in #461.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
