### PR TITLE
PLANNER-2388: Improve solver error message

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolverManager.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolverManager.java
@@ -112,8 +112,9 @@ class SolverManager implements SolverEventListener<VehicleRoutingSolution> {
                         // So this case is only possible when an exception is thrown during solver.solve().
                         try {
                             solverFuture.get();
-                            logger.error("This should be impossible. The solver has stopped without being terminated early"
-                                    + " so at this point it is expected to have crashed but there was no exception.");
+                            logger.error("The solver has stopped without being terminated early so at this point"
+                                    + " it is expected to have crashed but there was no exception.\n"
+                                    + "If you see this other than during test execution it is probably a bug.");
                             errorEvent.fire(new ErrorEvent(
                                     this,
                                     "Solver stopped without being terminated early and without throwing an exception."

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverExceptionTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverExceptionTest.java
@@ -72,7 +72,8 @@ class SolverExceptionTest {
         solverManager.startSolver(SolutionFactory.emptySolution());
 
         // assert
-        verify(eventPublisher).fire(any(ErrorEvent.class));
+        verify(eventPublisher).fire(errorEventArgumentCaptor.capture());
+        assertThat(errorEventArgumentCaptor.getValue().message).contains("This is a bug.");
     }
 
     @Test


### PR DESCRIPTION
### JIRA

https://issues.redhat.com/browse/PLANNER-2388

Improve error message to avoid confusion. It's inappropriate to use "impossible" for something that actually happens during test execution.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
