### PR TITLE
PLANNER-2389 Remove version overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,10 @@
 
   <properties>
     <version.com.graphhopper>0.13.0-pre13</version.com.graphhopper>
-    <version.com.h2database>1.4.199</version.com.h2database>
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
     <version.frontend-maven-plugin>1.10.0</version.frontend-maven-plugin>
     <version.node>v12.16.2</version.node>
     <version.npm>6.14.4</version.npm>
-    <version.org.hibernate>5.4.27.Final</version.org.hibernate>
-    <version.org.mockito>3.7.0</version.org.mockito>
     <!-- Override protobuf version from Quarkus to make it compatible with GraphHopper. -->
     <protobuf-java.version>3.6.1</protobuf-java.version>
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2389

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1254
https://github.com/kiegroup/optaplanner-quickstarts/pull/93
https://github.com/kiegroup/optaweb-employee-rostering/pull/602
https://github.com/kiegroup/optaweb-vehicle-routing/pull/471

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
