### PR TITLE
Increase timeout in a test

### DIFF
--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverIntegrationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverIntegrationTest.java
@@ -55,6 +55,8 @@ import org.slf4j.LoggerFactory;
 class SolverIntegrationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SolverIntegrationTest.class);
+    // Set a benevolent timeout to avoid issues in the CI environment.
+    private static final int PFC_PROPAGATION_TIMEOUT_MILLIS = 10_000;
 
     private SolverConfig solverConfig;
     private ExecutorService executor;
@@ -103,7 +105,7 @@ class SolverIntegrationTest {
             logger.info("Add visit ({})", id);
             monitor.beforeProblemFactChange();
             solver.addProblemFactChange(new AddVisit(fromLocation(testLocation(id, location -> distance))));
-            assertThat(monitor.awaitAllProblemFactChanges(1000)).isTrue();
+            assertThat(monitor.awaitAllProblemFactChanges(PFC_PROPAGATION_TIMEOUT_MILLIS)).isTrue();
         }
 
         List<Integer> visitIds = Arrays.asList(5, 2, 3);
@@ -116,7 +118,7 @@ class SolverIntegrationTest {
             // Notice that it's not possible to check individual problem fact changes completion.
             // When we receive a BestSolutionChangedEvent with unprocessed PFCs,
             // we don't know how many of them there are.
-            if (!monitor.awaitAllProblemFactChanges(1000)) {
+            if (!monitor.awaitAllProblemFactChanges(PFC_PROPAGATION_TIMEOUT_MILLIS)) {
                 assertThat(terminateSolver(solver)).isNotNull();
                 fail("Problem fact change hasn't been completed");
             }

--- a/optaweb-vehicle-routing-standalone/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-standalone/src/main/resources/application.properties
@@ -20,6 +20,7 @@ app.routing.gh-dir=local/graphhopper
 app.routing.osm-dir=local/openstreetmap
 app.routing.engine=GRAPHHOPPER
 app.routing.osm-file=belgium-latest.osm.pbf
+app.region.country-codes=BE
 
 # OptaPlanner
 quarkus.optaplanner.solver.daemon=true


### PR DESCRIPTION
There was a test failure in the release build due to a test that is marked as flaky on the master branch.

I am also cherry-picking [a fix](https://github.com/kiegroup/optaweb-vehicle-routing/commit/b58820123906bea6eb5a51269eefcf3c905e4b4c) that is missing on this branch.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
