### PR TITLE
Fix test logging

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -141,6 +141,16 @@
       <artifactId>jsonassert</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -181,6 +191,10 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+          <!-- Fix a logging issue during test execution (https://github.com/quarkusio/quarkus/issues/7696). -->
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.jboss.slf4j:slf4j-jboss-logmanager</classpathDependencyExclude>
+          </classpathDependencyExcludes>
         </configuration>
       </plugin>
       <plugin>

--- a/optaweb-vehicle-routing-backend/src/test/resources/logback-test.xml
+++ b/optaweb-vehicle-routing-backend/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!--  <logger name="org.drools" level="debug"/>-->
+  <!--  <logger name="org.optaplanner" level="debug"/>-->
+  <!--  <logger name="org.optaweb" level="debug"/>-->
+
+  <root level="info">
+    <appender-ref ref="consoleAppender"/>
+  </root>
+</configuration>


### PR DESCRIPTION
No logging output is visible during test execution. The issue is also described in https://github.com/quarkusio/quarkus/issues/7696.

Excluding `org.jboss.slf4j:slf4j-jboss-logmanager` from test classpath and using `logback-classic` in the test scope fixes that.

## Update

The logging issue only happens when there is a lot of logging output at the beginning of surefire execution, so at the beginning of the first test in the whole suite.

I came across this when debugging `SolverIntegrationTest` that runs solver. On the first problem fact change, Drools performs some initial compilation and produces significant amount of logging output (on debug level, which is active by default during test execution). When this happens at the beginning of test execution, `LogManager` fails to handle that. Visible output:

```
LogManager error of type WRITE_FAILURE: The delayed handler's queue was overrun and log record(s) were lost. Did you forget to configure logging?
```

The message is coming from https://github.com/quarkusio/quarkus/blob/1.13.4.Final/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java#L90.

So, the described issue is a corner case that typically only happens when running a single test that does a lot of logging. That seems to be a rare condition in this repo. It makes debugging more difficult if it happens but since it is a corner case I don't the fix is worth the extra code.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
