### PR TITLE
Replace deprecated ConfigProperties with ConfigMapping

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/RoutingConfig.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/RoutingConfig.java
@@ -60,11 +60,11 @@ class RoutingConfig {
 
     @Inject
     RoutingConfig(RoutingProperties routingProperties) {
-        osmDir = Paths.get(routingProperties.getOsmDir()).toAbsolutePath();
-        osmFile = osmDir.resolve(routingProperties.getOsmFile()).toAbsolutePath();
-        osmDownloadUrl = routingProperties.getOsmDownloadUrl();
-        graphHopperDir = Paths.get(routingProperties.getGhDir());
-        String regionName = routingProperties.getOsmFile().replaceFirst("\\.osm\\.pbf$", "");
+        osmDir = Paths.get(routingProperties.osmDir()).toAbsolutePath();
+        osmFile = osmDir.resolve(routingProperties.osmFile()).toAbsolutePath();
+        osmDownloadUrl = routingProperties.osmDownloadUrl();
+        graphHopperDir = Paths.get(routingProperties.ghDir());
+        String regionName = routingProperties.osmFile().replaceFirst("\\.osm\\.pbf$", "");
         graphDir = graphHopperDir.resolve(regionName).toAbsolutePath();
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/RoutingProperties.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/RoutingProperties.java
@@ -18,77 +18,37 @@ package org.optaweb.vehiclerouting.plugin.routing;
 
 import java.util.Optional;
 
-import io.quarkus.arc.config.ConfigProperties;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigProperties(prefix = "app.routing")
-public class RoutingProperties {
+@ConfigMapping(prefix = "app.routing")
+interface RoutingProperties {
 
     /**
      * Directory to read OSM files from.
      */
-    private String osmDir = "local/openstreetmap";
+    String osmDir();
 
     /**
      * Directory where GraphHopper graphs are stored.
      */
-    private String ghDir = "local/graphhopper";
+    String ghDir();
 
     /**
      * OpenStreetMap file name.
      */
-    private String osmFile;
+    String osmFile();
 
     /**
      * URL of an .osm.pbf file that will be downloaded in case the file doesn't exist on the file system.
      */
-    private Optional<String> osmDownloadUrl;
+    Optional<String> osmDownloadUrl();
 
     /**
      * Routing engine providing distances and paths.
      */
-    private RoutingEngine engine;
+    RoutingEngine engine();
 
-    public String getOsmDir() {
-        return osmDir;
-    }
-
-    public void setOsmDir(String osmDir) {
-        this.osmDir = osmDir;
-    }
-
-    public String getGhDir() {
-        return ghDir;
-    }
-
-    public void setGhDir(String ghDir) {
-        this.ghDir = ghDir;
-    }
-
-    public String getOsmFile() {
-        return osmFile;
-    }
-
-    public void setOsmFile(String osmFile) {
-        this.osmFile = osmFile;
-    }
-
-    public Optional<String> getOsmDownloadUrl() {
-        return osmDownloadUrl;
-    }
-
-    public void setOsmDownloadUrl(Optional<String> osmDownloadUrl) {
-        this.osmDownloadUrl = osmDownloadUrl;
-    }
-
-    public RoutingEngine getEngine() {
-        return engine;
-    }
-
-    public void setEngine(RoutingEngine engine) {
-        this.engine = engine;
-    }
-
-    public enum RoutingEngine {
+    enum RoutingEngine {
         AIR,
         GRAPHHOPPER
     }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/DemoProperties.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/DemoProperties.java
@@ -18,21 +18,13 @@ package org.optaweb.vehiclerouting.service.demo;
 
 import java.util.Optional;
 
-import io.quarkus.arc.config.ConfigProperties;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigProperties(prefix = "app.demo")
-public class DemoProperties {
+@ConfigMapping(prefix = "app.demo")
+interface DemoProperties {
 
     /**
      * Directory with demo data sets.
      */
-    private Optional<String> dataSetDir;
-
-    public Optional<String> getDataSetDir() {
-        return dataSetDir;
-    }
-
-    public void setDataSetDir(Optional<String> dataSetDir) {
-        this.dataSetDir = dataSetDir;
-    }
+    Optional<String> dataSetDir();
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemConfig.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemConfig.java
@@ -97,7 +97,7 @@ class RoutingProblemConfig {
 
     private Optional<Path> dataSetDir() {
         // TODO watch the dir (and make this a service that has local/data resource as a dependency -> is testable)
-        Optional<String> dataSetDirProperty = demoProperties.getDataSetDir();
+        Optional<String> dataSetDirProperty = demoProperties.dataSetDir();
         if (!dataSetDirProperty.isPresent()) {
             logger.info("Data set directory (app.demo.data-set-dir) is not set.");
             return Optional.empty();

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/region/RegionProperties.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/region/RegionProperties.java
@@ -16,31 +16,18 @@
 
 package org.optaweb.vehiclerouting.service.region;
 
-import java.util.Collections;
 import java.util.List;
 
-import org.optaweb.vehiclerouting.domain.CountryCodeValidator;
+import io.smallrye.config.ConfigMapping;
 
-import io.quarkus.arc.config.ConfigProperties;
-
-@ConfigProperties(prefix = "app.region")
-public class RegionProperties {
+@ConfigMapping(prefix = "app.region")
+interface RegionProperties {
 
     /**
-     * List of ISO 3166-1 alpha-2 country code(s) matching the loaded OSM file.
-     */
-    private List<String> countryCodes = Collections.emptyList();
-
-    /**
-     * Get country codes matching the loaded OSM file (working region).
+     * Get country codes specified for the loaded OSM file (working region).
+     * The codes are expected to be in the ISO 3166-1 alpha-2 format.
      *
      * @return list of country codes (never {@code null})
      */
-    public List<String> getCountryCodes() {
-        return Collections.unmodifiableList(countryCodes);
-    }
-
-    public void setCountryCodes(List<String> countryCodes) {
-        this.countryCodes = CountryCodeValidator.validate(countryCodes);
-    }
+    List<String> countryCodes();
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/region/RegionService.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/region/RegionService.java
@@ -42,7 +42,7 @@ public class RegionService {
      * @return country codes (never {@code null})
      */
     public List<String> countryCodes() {
-        return regionProperties.getCountryCodes();
+        return regionProperties.countryCodes();
     }
 
     /**

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/region/RegionPropertiesTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/region/RegionPropertiesTest.java
@@ -32,6 +32,6 @@ class RegionPropertiesTest {
 
     @Test
     void test() {
-        assertThat(regionProperties.getCountryCodes()).containsExactly("AT", "DE");
+        assertThat(regionProperties.countryCodes()).containsExactly("AT", "DE");
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/region/RegionServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/region/RegionServiceTest.java
@@ -42,7 +42,7 @@ class RegionServiceTest {
     @Test
     void should_return_country_codes_from_properties() {
         List<String> countryCodes = Arrays.asList("XY", "WZ");
-        when(regionProperties.getCountryCodes()).thenReturn(countryCodes);
+        when(regionProperties.countryCodes()).thenReturn(countryCodes);
 
         assertThat(regionService.countryCodes()).isEqualTo(countryCodes);
     }


### PR DESCRIPTION
`@ConfingProperties` became deprecated in Quarkus 2.0.0.

SmallRye documentation:
https://smallrye.io/docs/smallrye-config/mapping/mapping.html

Do not merge before we upgrade to a Quarkus version that brings `smallrye-config` at least 2.4.0. Done: kiegroup/optaplanner/pull/1451.

We need https://github.com/smallrye/smallrye-config/pull/600 that fixes a problem with `.env` file containing for example `APP_DEMO_DATA_SET_DIR`.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
