### PR TITLE
BXMSPROD-1413 [7.x] [build-chain upgrade] exclude projects not taken into account

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@BXMSPROD-1413
+        uses: kiegroup/github-action-build-chain@v2.6.4
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.3
+        uses: kiegroup/github-action-build-chain@BXMSPROD-1413
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml
         env:


### PR DESCRIPTION
The build chain tool is not properly taken into account for excluded projects. https://github.com/kiegroup/github-action-build-chain/pull/160 solves the problem

related PR
- https://github.com/kiegroup/github-action-build-chain/pull/160
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/527
- https://github.com/kiegroup/optaweb-employee-rostering/pull/654
- https://github.com/kiegroup/optaplanner/pull/1418
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/528
- https://github.com/kiegroup/optaweb-employee-rostering/pull/655

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
