### PR TITLE
Rename Coordinates factory method to "of()"

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Coordinates.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/domain/Coordinates.java
@@ -33,13 +33,13 @@ public class Coordinates {
     }
 
     /**
-     * Create coordinates from the given latitude in longitude.
+     * Create coordinates with the given latitude and longitude.
      *
      * @param latitude latitude
      * @param longitude longitude
      * @return coordinates with the given latitude and longitude
      */
-    public static Coordinates valueOf(double latitude, double longitude) {
+    public static Coordinates of(double latitude, double longitude) {
         return new Coordinates(BigDecimal.valueOf(latitude), BigDecimal.valueOf(longitude));
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/AirDistanceRouter.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/AirDistanceRouter.java
@@ -56,6 +56,6 @@ public class AirDistanceRouter implements Router, DistanceCalculator, Region {
 
     @Override
     public BoundingBox getBounds() {
-        return new BoundingBox(Coordinates.valueOf(-90, -180), Coordinates.valueOf(90, 180));
+        return new BoundingBox(Coordinates.of(-90, -180), Coordinates.of(90, 180));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouter.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouter.java
@@ -62,7 +62,7 @@ class GraphHopperRouter implements Router, DistanceCalculator, Region {
                 to.longitude().doubleValue());
         PointList points = graphHopper.route(ghRequest).getBest().getPoints();
         return StreamSupport.stream(points.spliterator(), false)
-                .map(ghPoint3D -> Coordinates.valueOf(ghPoint3D.lat, ghPoint3D.lon))
+                .map(ghPoint3D -> Coordinates.of(ghPoint3D.lat, ghPoint3D.lon))
                 .collect(toList());
     }
 
@@ -85,7 +85,7 @@ class GraphHopperRouter implements Router, DistanceCalculator, Region {
     public BoundingBox getBounds() {
         BBox bounds = graphHopper.getGraphHopperStorage().getBounds();
         return new BoundingBox(
-                Coordinates.valueOf(bounds.minLat, bounds.minLon),
-                Coordinates.valueOf(bounds.maxLat, bounds.maxLon));
+                Coordinates.of(bounds.minLat, bounds.minLon),
+                Coordinates.of(bounds.maxLat, bounds.maxLon));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshaller.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshaller.java
@@ -137,7 +137,7 @@ public class DataSetMarshaller {
 
     static LocationData toDomain(DataSetLocation dataSetLocation) {
         return new LocationData(
-                Coordinates.valueOf(dataSetLocation.getLatitude(), dataSetLocation.getLongitude()),
+                Coordinates.of(dataSetLocation.getLatitude(), dataSetLocation.getLongitude()),
                 dataSetLocation.getLabel());
     }
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/CoordinatesTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/CoordinatesTest.java
@@ -63,7 +63,7 @@ class CoordinatesTest {
     void valueOf_and_getters() {
         double latitude = Math.E;
         double longitude = Math.PI;
-        Coordinates coordinates = Coordinates.valueOf(latitude, longitude);
+        Coordinates coordinates = Coordinates.of(latitude, longitude);
         assertThat(coordinates.latitude()).isEqualTo(BigDecimal.valueOf(latitude));
         assertThat(coordinates.longitude()).isEqualTo(BigDecimal.valueOf(longitude));
     }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LocationDataTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LocationDataTest.java
@@ -28,7 +28,7 @@ class LocationDataTest {
     @Test
     void constructor_params_must_not_be_null() {
         assertThatNullPointerException().isThrownBy(() -> new LocationData(null, ""));
-        assertThatNullPointerException().isThrownBy(() -> new LocationData(Coordinates.valueOf(1, 1), null));
+        assertThatNullPointerException().isThrownBy(() -> new LocationData(Coordinates.of(1, 1), null));
     }
 
     @Test

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LocationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/LocationTest.java
@@ -28,7 +28,7 @@ class LocationTest {
     @Test
     void constructor_params_must_not_be_null() {
         assertThatNullPointerException().isThrownBy(() -> new Location(0, null, ""));
-        assertThatNullPointerException().isThrownBy(() -> new Location(0, Coordinates.valueOf(1, 1), null));
+        assertThatNullPointerException().isThrownBy(() -> new Location(0, Coordinates.of(1, 1), null));
     }
 
     @Test
@@ -60,12 +60,12 @@ class LocationTest {
     @Test
     void equal_locations_must_have_same_hashcode() {
         long id = 1;
-        assertThat(new Location(id, Coordinates.valueOf(1, 1), "description 1"))
-                .hasSameHashCodeAs(new Location(id, Coordinates.valueOf(2, 2), "description 2"));
+        assertThat(new Location(id, Coordinates.of(1, 1), "description 1"))
+                .hasSameHashCodeAs(new Location(id, Coordinates.of(2, 2), "description 2"));
     }
 
     @Test
     void constructor_without_description_should_create_empty_description() {
-        assertThat(new Location(7, Coordinates.valueOf(3.14, 4.13)).description()).isEmpty();
+        assertThat(new Location(7, Coordinates.of(3.14, 4.13)).description()).isEmpty();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteTest.java
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.Test;
 class RouteTest {
 
     private final Vehicle vehicle = VehicleFactory.testVehicle(4);
-    private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
-    private final Location visit1 = new Location(2, Coordinates.valueOf(5, 5));
-    private final Location visit2 = new Location(3, Coordinates.valueOf(5, 5));
+    private final Location depot = new Location(1, Coordinates.of(5, 5));
+    private final Location visit1 = new Location(2, Coordinates.of(5, 5));
+    private final Location visit2 = new Location(3, Coordinates.of(5, 5));
 
     @Test
     void constructor_args_not_null() {

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteWithTrackTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RouteWithTrackTest.java
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.Test;
 class RouteWithTrackTest {
 
     private final Vehicle vehicle = VehicleFactory.testVehicle(4);
-    private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
-    private final Location visit1 = new Location(2, Coordinates.valueOf(5, 5));
-    private final Location visit2 = new Location(3, Coordinates.valueOf(5, 5));
+    private final Location depot = new Location(1, Coordinates.of(5, 5));
+    private final Location visit1 = new Location(2, Coordinates.of(5, 5));
+    private final Location visit2 = new Location(3, Coordinates.of(5, 5));
 
     @Test
     void constructor_args_not_null() {
@@ -45,7 +45,7 @@ class RouteWithTrackTest {
     void cannot_modify_track_externally() {
         Route route = new Route(vehicle, depot, Arrays.asList(visit1, visit2));
         ArrayList<List<Coordinates>> track = new ArrayList<>();
-        track.add(Arrays.asList(Coordinates.valueOf(1.0, 2.0)));
+        track.add(Arrays.asList(Coordinates.of(1.0, 2.0)));
 
         List<List<Coordinates>> routeTrack = new RouteWithTrack(route, track).track();
         assertThatExceptionOfType(UnsupportedOperationException.class)
@@ -56,7 +56,7 @@ class RouteWithTrackTest {
     void when_route_is_empty_track_must_be_empty() {
         Route emptyRoute = new Route(vehicle, depot, emptyList());
         ArrayList<List<Coordinates>> track = new ArrayList<>();
-        track.add(Arrays.asList(Coordinates.valueOf(1.0, 2.0)));
+        track.add(Arrays.asList(Coordinates.of(1.0, 2.0)));
 
         assertThatIllegalArgumentException().isThrownBy(() -> new RouteWithTrack(emptyRoute, track));
     }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/domain/RoutingPlanTest.java
@@ -35,11 +35,11 @@ class RoutingPlanTest {
     private final Distance distance = Distance.ofMillis(1);
     private final Vehicle vehicle = VehicleFactory.testVehicle(1);
     private final List<Vehicle> vehicles = singletonList(vehicle);
-    private final Location depot = new Location(1, Coordinates.valueOf(5, 5));
-    private final Location visit = new Location(2, Coordinates.valueOf(3, 3));
+    private final Location depot = new Location(1, Coordinates.of(5, 5));
+    private final Location visit = new Location(2, Coordinates.of(3, 3));
     private final RouteWithTrack emptyRoute = new RouteWithTrack(new Route(vehicle, depot, emptyList()), emptyList());
     // Track is not important (we don't check if track starts and ends in the depot and goes through all visits)
-    private final List<List<Coordinates>> nonEmptyTrack = singletonList(singletonList(Coordinates.valueOf(5, 5)));
+    private final List<List<Coordinates>> nonEmptyTrack = singletonList(singletonList(Coordinates.of(5, 5)));
 
     @Test
     void constructor_args_not_null() {
@@ -92,10 +92,10 @@ class RoutingPlanTest {
         Vehicle vehicle1 = VehicleFactory.testVehicle(1);
         Vehicle vehicle2 = VehicleFactory.testVehicle(2);
 
-        Location depot = new Location(100, Coordinates.valueOf(0, 0), "depot");
-        Location visit1 = new Location(101, Coordinates.valueOf(1, 1), "visit1");
-        Location visit2 = new Location(102, Coordinates.valueOf(2, 2), "visit2");
-        Location visit3 = new Location(103, Coordinates.valueOf(3, 3), "visit3");
+        Location depot = new Location(100, Coordinates.of(0, 0), "depot");
+        Location visit1 = new Location(101, Coordinates.of(1, 1), "visit1");
+        Location visit2 = new Location(102, Coordinates.of(2, 2), "visit2");
+        Location visit3 = new Location(103, Coordinates.of(3, 3), "visit3");
 
         assertThatCode(() -> new RoutingPlan(
                 distance,
@@ -115,7 +115,7 @@ class RoutingPlanTest {
                         new RouteWithTrack(new Route(vehicle1, depot, asList(visit1, visit2, visit3)), nonEmptyTrack))))
                 .withMessageContaining(visit3.toString());
 
-        Location visit4 = new Location(104, Coordinates.valueOf(4, 4), "visit4");
+        Location visit4 = new Location(104, Coordinates.of(4, 4), "visit4");
         assertThatIllegalArgumentException().isThrownBy(() -> new RoutingPlan(
                 distance,
                 asList(vehicle1, vehicle2),

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceRepositoryImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceRepositoryImplTest.java
@@ -44,8 +44,8 @@ class DistanceRepositoryImplTest {
     @Captor
     private ArgumentCaptor<DistanceEntity> distanceEntityArgumentCaptor;
 
-    private final Location from = new Location(1, Coordinates.valueOf(7, -4.0));
-    private final Location to = new Location(2, Coordinates.valueOf(5, 9.0));
+    private final Location from = new Location(1, Coordinates.of(7, -4.0));
+    private final Location to = new Location(2, Coordinates.of(5, 9.0));
 
     @Test
     void should_save_distance() {

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceRepositoryIntegrationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/DistanceRepositoryIntegrationTest.java
@@ -83,8 +83,8 @@ class DistanceRepositoryIntegrationTest {
     @Test
     @TestTransaction
     void should_return_saved_distance() {
-        Location location1 = new Location(1, Coordinates.valueOf(7, -4.0));
-        Location location2 = new Location(2, Coordinates.valueOf(5, 9.0));
+        Location location1 = new Location(1, Coordinates.of(7, -4.0));
+        Location location2 = new Location(2, Coordinates.of(5, 9.0));
 
         Distance distance = Distance.ofMillis(956766417);
         repository.saveDistance(location1, location2, distance);
@@ -93,8 +93,8 @@ class DistanceRepositoryIntegrationTest {
 
     @Test
     void should_return_negative_number_when_distance_not_found() {
-        Location location1 = new Location(1, Coordinates.valueOf(7, -4.0));
-        Location location2 = new Location(2, Coordinates.valueOf(5, 9.0));
+        Location location1 = new Location(1, Coordinates.of(7, -4.0));
+        Location location2 = new Location(2, Coordinates.of(5, 9.0));
 
         assertThat(repository.getDistance(location1, location2)).isEmpty();
     }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryImplTest.java
@@ -45,7 +45,7 @@ class LocationRepositoryImplTest {
     @Captor
     private ArgumentCaptor<LocationEntity> locationEntityCaptor;
 
-    private final Location testLocation = new Location(76, Coordinates.valueOf(1.2, 3.4), "description");
+    private final Location testLocation = new Location(76, Coordinates.of(1.2, 3.4), "description");
 
     private static LocationEntity locationEntity(Location location) {
         return new LocationEntity(
@@ -58,7 +58,7 @@ class LocationRepositoryImplTest {
     @Test
     void should_create_location() {
         // arrange
-        Coordinates savedCoordinates = Coordinates.valueOf(0.00213, 32.777);
+        Coordinates savedCoordinates = Coordinates.of(0.00213, 32.777);
         String savedDescription = "new location";
 
         // act

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryIntegrationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/persistence/LocationRepositoryIntegrationTest.java
@@ -67,7 +67,7 @@ class LocationRepositoryIntegrationTest {
     @Test
     @TestTransaction
     void remove_created_location() {
-        Coordinates coordinates = Coordinates.valueOf(0.00213, 32.777);
+        Coordinates coordinates = Coordinates.of(0.00213, 32.777);
         assertThat(crudRepository.count()).isZero();
         Location location = repository.createLocation(coordinates, "");
         assertThat(location.coordinates()).isEqualTo(coordinates);
@@ -90,7 +90,7 @@ class LocationRepositoryIntegrationTest {
     void get_and_remove_all_locations() {
         int locationCount = 8;
         for (int i = 0; i < locationCount; i++) {
-            repository.createLocation(Coordinates.valueOf(1.0, i / 100.0), "");
+            repository.createLocation(Coordinates.of(1.0, i / 100.0), "");
         }
 
         assertThat(crudRepository.count()).isEqualTo(locationCount);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImplTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/RouteOptimizerImplTest.java
@@ -52,9 +52,9 @@ import org.optaweb.vehiclerouting.service.location.DistanceMatrixRow;
 class RouteOptimizerImplTest {
 
     private final DistanceMatrixRow matrixRow = locationId -> Distance.ZERO;
-    private final Location location1 = new Location(1, Coordinates.valueOf(1.0, 0.1));
-    private final Location location2 = new Location(2, Coordinates.valueOf(0.2, 2.2));
-    private final Location location3 = new Location(3, Coordinates.valueOf(3.4, 5.6));
+    private final Location location1 = new Location(1, Coordinates.of(1.0, 0.1));
+    private final Location location2 = new Location(2, Coordinates.of(0.2, 2.2));
+    private final Location location3 = new Location(3, Coordinates.of(3.4, 5.6));
 
     @Captor
     private ArgumentCaptor<VehicleRoutingSolution> solutionArgumentCaptor;

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/domain/PlanningLocationFactoryTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/domain/PlanningLocationFactoryTest.java
@@ -31,7 +31,7 @@ class PlanningLocationFactoryTest {
         double latitude = -20.5;
         double longitude = 11.7;
         long distance = 11234;
-        Location location = new Location(id, Coordinates.valueOf(latitude, longitude));
+        Location location = new Location(id, Coordinates.of(latitude, longitude));
         PlanningLocation planningLocation = PlanningLocationFactory.fromDomain(location, otherLocation -> distance);
         assertThat(planningLocation.getId()).isEqualTo(id);
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/domain/PlanningLocationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/domain/PlanningLocationTest.java
@@ -37,7 +37,7 @@ class PlanningLocationTest {
         long otherId = 321;
         long millis = 777777;
         distanceMap.put(otherId, Distance.ofMillis(millis));
-        Location domainLocation = new Location(1, Coordinates.valueOf(0, 0));
+        Location domainLocation = new Location(1, Coordinates.of(0, 0));
 
         PlanningLocation planningLocation = new PlanningLocation(
                 domainLocation.id(),

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/weight/DepotAngleVisitDifficultyWeightFactoryTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/weight/DepotAngleVisitDifficultyWeightFactoryTest.java
@@ -49,7 +49,7 @@ class DepotAngleVisitDifficultyWeightFactoryTest {
     private final DepotAngleVisitDifficultyWeightFactory weightFactory = new DepotAngleVisitDifficultyWeightFactory();
 
     DepotAngleVisitDifficultyWeightFactoryTest() {
-        Location depotLocation = new Location(0, Coordinates.valueOf(depotY, depotX));
+        Location depotLocation = new Location(0, Coordinates.of(depotY, depotX));
         depot = fromDomain(depotLocation, new DistanceMapImpl(depotDistanceMap::get));
         solution.getDepotList().add(new PlanningDepot(depot));
     }
@@ -67,7 +67,7 @@ class DepotAngleVisitDifficultyWeightFactoryTest {
         depotDistanceMap.put(id, Distance.ofMillis(depotToLocation));
         Map<Long, Distance> locationDistanceMap = new HashMap<>();
         locationDistanceMap.put(depot.getId(), Distance.ofMillis(locationToDepot));
-        Location domainLocation = new Location(id, Coordinates.valueOf(latitude, longitude));
+        Location domainLocation = new Location(id, Coordinates.of(latitude, longitude));
         return fromDomain(domainLocation, new DistanceMapImpl(locationDistanceMap::get));
     }
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/LocationResourceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/LocationResourceTest.java
@@ -37,7 +37,7 @@ class LocationResourceTest {
 
     @Test
     void addLocation() {
-        Coordinates coords = Coordinates.valueOf(0.0, 1.0);
+        Coordinates coords = Coordinates.of(0.0, 1.0);
         String description = "new location";
         PortableLocation request = new PortableLocation(321, coords.latitude(), coords.longitude(), description);
         locationResource.addLocation(request);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/ServerInfoResourceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/ServerInfoResourceTest.java
@@ -56,13 +56,13 @@ class ServerInfoResourceTest {
         List<String> countryCodes = Arrays.asList("XY", "WZ");
         when(regionService.countryCodes()).thenReturn(countryCodes);
 
-        Coordinates southWest = Coordinates.valueOf(-1.0, -2.0);
-        Coordinates northEast = Coordinates.valueOf(1.0, 2.0);
+        Coordinates southWest = Coordinates.of(-1.0, -2.0);
+        Coordinates northEast = Coordinates.of(1.0, 2.0);
         BoundingBox boundingBox = new BoundingBox(southWest, northEast);
         when(regionService.boundingBox()).thenReturn(boundingBox);
 
-        Location depot = new Location(1, Coordinates.valueOf(1.0, 7), "Depot");
-        List<Location> visits = Arrays.asList(new Location(2, Coordinates.valueOf(2.0, 9), "Visit"));
+        Location depot = new Location(1, Coordinates.of(1.0, 7), "Depot");
+        List<Location> visits = Arrays.asList(new Location(2, Coordinates.of(2.0, 9), "Visit"));
         List<Vehicle> vehicles = Arrays.asList(VehicleFactory.testVehicle(1));
         String demoName = "Testing problem";
         RoutingProblem routingProblem = new RoutingProblem(demoName, vehicles, depot, visits);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableCoordinatesTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableCoordinatesTest.java
@@ -50,7 +50,7 @@ class PortableCoordinatesTest {
 
     @Test
     void conversion_from_domain() {
-        Coordinates coordinates = Coordinates.valueOf(0.04687, -88.8889);
+        Coordinates coordinates = Coordinates.of(0.04687, -88.8889);
         PortableCoordinates portableCoordinates = PortableCoordinates.fromCoordinates(coordinates);
         assertThat(portableCoordinates.getLatitude()).isEqualTo(coordinates.latitude());
         assertThat(portableCoordinates.getLongitude()).isEqualTo(coordinates.longitude());
@@ -62,8 +62,8 @@ class PortableCoordinatesTest {
 
     @Test
     void should_reduce_scale_if_needed() {
-        Coordinates coordinates = Coordinates.valueOf(0.123450001, -88.999999999);
-        Coordinates scaledDown = Coordinates.valueOf(0.12345, -89);
+        Coordinates coordinates = Coordinates.of(0.123450001, -88.999999999);
+        Coordinates scaledDown = Coordinates.of(0.12345, -89);
         PortableCoordinates portableCoordinates = PortableCoordinates.fromCoordinates(coordinates);
         assertThat(portableCoordinates.getLatitude()).isEqualTo(scaledDown.latitude());
         assertThat(portableCoordinates.getLongitude()).isEqualByComparingTo(scaledDown.longitude());

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableLocationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableLocationTest.java
@@ -67,7 +67,7 @@ class PortableLocationTest {
 
     @Test
     void fromLocation() {
-        Location location = new Location(17, Coordinates.valueOf(5.1, -0.0007), "Hello, world!");
+        Location location = new Location(17, Coordinates.of(5.1, -0.0007), "Hello, world!");
         PortableLocation portableLocation = PortableLocation.fromLocation(location);
         assertThat(portableLocation.getId()).isEqualTo(location.id());
         assertThat(portableLocation.getLatitude()).isEqualTo(location.coordinates().latitude());

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableRouteTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableRouteTest.java
@@ -63,10 +63,10 @@ class PortableRouteTest {
     }
 
     private static PortableLocation visit(long id, double latitude, double longitude, String description) {
-        return fromLocation(new Location(id, Coordinates.valueOf(latitude, longitude), description));
+        return fromLocation(new Location(id, Coordinates.of(latitude, longitude), description));
     }
 
     private static PortableCoordinates coordinates(double latitude, double longitude) {
-        return fromCoordinates(Coordinates.valueOf(latitude, longitude));
+        return fromCoordinates(Coordinates.of(latitude, longitude));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableRoutingPlanFactoryTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/rest/model/PortableRoutingPlanFactoryTest.java
@@ -46,13 +46,13 @@ class PortableRoutingPlanFactoryTest {
     @Test
     void portable_routing_plan_with_two_routes() {
         // arrange
-        final Coordinates coordinates1 = Coordinates.valueOf(0.0, 0.1);
-        final Coordinates coordinates2 = Coordinates.valueOf(2.0, -0.2);
-        final Coordinates coordinates3 = Coordinates.valueOf(3.3, -3.3);
-        final Coordinates checkpoint12 = Coordinates.valueOf(12, 12);
-        final Coordinates checkpoint21 = Coordinates.valueOf(21, 21);
-        final Coordinates checkpoint13 = Coordinates.valueOf(13, 13);
-        final Coordinates checkpoint31 = Coordinates.valueOf(31, 31);
+        final Coordinates coordinates1 = Coordinates.of(0.0, 0.1);
+        final Coordinates coordinates2 = Coordinates.of(2.0, -0.2);
+        final Coordinates coordinates3 = Coordinates.of(3.3, -3.3);
+        final Coordinates checkpoint12 = Coordinates.of(12, 12);
+        final Coordinates checkpoint21 = Coordinates.of(21, 21);
+        final Coordinates checkpoint13 = Coordinates.of(13, 13);
+        final Coordinates checkpoint31 = Coordinates.of(31, 31);
         List<Coordinates> segment12 = asList(coordinates1, checkpoint12, coordinates2);
         List<Coordinates> segment21 = asList(coordinates2, checkpoint21, coordinates1);
         List<Coordinates> segment13 = asList(coordinates1, checkpoint13, coordinates3);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/AirDistanceRouterTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/AirDistanceRouterTest.java
@@ -27,8 +27,8 @@ class AirDistanceRouterTest {
     @Test
     void travel_time_should_be_distance_divided_by_speed() {
         AirDistanceRouter router = new AirDistanceRouter();
-        Coordinates from = Coordinates.valueOf(0, 0);
-        Coordinates to = Coordinates.valueOf(3, 4); // √(3² + 4²) = 5
+        Coordinates from = Coordinates.of(0, 0);
+        Coordinates to = Coordinates.of(3, 4); // √(3² + 4²) = 5
         long travelTimeMillis = router.travelTimeMillis(from, to);
         assertThat(travelTimeMillis).isEqualTo((long) (5
                 * AirDistanceRouter.KILOMETERS_PER_DEGREE
@@ -39,15 +39,15 @@ class AirDistanceRouterTest {
     @Test
     void bounding_box_is_the_whole_globe() {
         BoundingBox bounds = new AirDistanceRouter().getBounds();
-        assertThat(bounds.getSouthWest()).isEqualTo(Coordinates.valueOf(-90, -180));
-        assertThat(bounds.getNorthEast()).isEqualTo(Coordinates.valueOf(90, 180));
+        assertThat(bounds.getSouthWest()).isEqualTo(Coordinates.of(-90, -180));
+        assertThat(bounds.getNorthEast()).isEqualTo(Coordinates.of(90, 180));
     }
 
     @Test
     void path_from_a_to_b_should_be_the_line_ab() {
         AirDistanceRouter router = new AirDistanceRouter();
-        Coordinates from = Coordinates.valueOf(0, 0);
-        Coordinates to = Coordinates.valueOf(3, 4);
+        Coordinates from = Coordinates.of(0, 0);
+        Coordinates to = Coordinates.of(3, 4);
         assertThat(router.getPath(from, to)).containsExactly(from, to);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouterTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouterTest.java
@@ -43,8 +43,8 @@ import com.graphhopper.util.shapes.BBox;
 class GraphHopperRouterTest {
 
     private final PointList pointList = new PointList();
-    private final Coordinates from = Coordinates.valueOf(-Double.MIN_VALUE, Double.MIN_VALUE);
-    private final Coordinates to = Coordinates.valueOf(Double.MAX_VALUE, -Double.MAX_VALUE);
+    private final Coordinates from = Coordinates.of(-Double.MIN_VALUE, Double.MIN_VALUE);
+    private final Coordinates to = Coordinates.of(Double.MAX_VALUE, -Double.MAX_VALUE);
     @Mock
     private GraphHopperOSM graphHopper;
     @Mock
@@ -96,9 +96,9 @@ class GraphHopperRouterTest {
         whenBestReturnPath();
         when(pathWrapper.getPoints()).thenReturn(pointList);
 
-        Coordinates coordinates1 = Coordinates.valueOf(1, 1);
-        Coordinates coordinates2 = Coordinates.valueOf(Math.E, Math.PI);
-        Coordinates coordinates3 = Coordinates.valueOf(0.1, 1.0 / 3.0);
+        Coordinates coordinates1 = Coordinates.of(1, 1);
+        Coordinates coordinates2 = Coordinates.of(Math.E, Math.PI);
+        Coordinates coordinates3 = Coordinates.of(0.1, 1.0 / 3.0);
 
         pointList.add(coordinates1.latitude().doubleValue(), coordinates1.longitude().doubleValue());
         pointList.add(coordinates2.latitude().doubleValue(), coordinates2.longitude().doubleValue());
@@ -124,7 +124,7 @@ class GraphHopperRouterTest {
 
         BoundingBox boundingBox = new GraphHopperRouter(graphHopper).getBounds();
 
-        assertThat(boundingBox.getSouthWest()).isEqualTo(Coordinates.valueOf(minLat_Y, minLon_X));
-        assertThat(boundingBox.getNorthEast()).isEqualTo(Coordinates.valueOf(maxLat_Y, maxLon_X));
+        assertThat(boundingBox.getSouthWest()).isEqualTo(Coordinates.of(minLat_Y, minLon_X));
+        assertThat(boundingBox.getNorthEast()).isEqualTo(Coordinates.of(maxLat_Y, maxLon_X));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/DemoServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/DemoServiceTest.java
@@ -74,8 +74,8 @@ class DemoServiceTest {
     private final List<VehicleData> vehicles = Arrays.asList(
             VehicleFactory.vehicleData("v1", 10),
             VehicleFactory.vehicleData("v2", 10));
-    private final Location depot = new Location(1, Coordinates.valueOf(1.0, 7), "Depot");
-    private final List<Location> visits = Arrays.asList(new Location(2, Coordinates.valueOf(2.0, 9), "Visit"));
+    private final Location depot = new Location(1, Coordinates.of(1.0, 7), "Depot");
+    private final List<Location> visits = Arrays.asList(new Location(2, Coordinates.of(2.0, 9), "Visit"));
     private final RoutingProblem routingProblem = new RoutingProblem(problemName, vehicles, depot, visits);
 
     @Test
@@ -91,7 +91,7 @@ class DemoServiceTest {
     @Test
     void loadDemo() {
         // arrange
-        Location location = new Location(10, Coordinates.valueOf(1, 2));
+        Location location = new Location(10, Coordinates.of(1, 2));
         when(routingProblems.byName(problemName)).thenReturn(routingProblem);
         when(locationService.createLocation(any(Coordinates.class), anyString())).thenReturn(Optional.of(location));
         // act
@@ -115,9 +115,9 @@ class DemoServiceTest {
 
     @Test
     void export_should_marshal_routing_plans_with_locations_and_vehicles_from_repository() {
-        Location depot = new Location(0, Coordinates.valueOf(1.0, 2.0), "Depot");
-        Location visit1 = new Location(1, Coordinates.valueOf(11.0, 22.0), "Visit 1");
-        Location visit2 = new Location(2, Coordinates.valueOf(22.0, 33.0), "Visit 2");
+        Location depot = new Location(0, Coordinates.of(1.0, 2.0), "Depot");
+        Location visit1 = new Location(1, Coordinates.of(11.0, 22.0), "Visit 1");
+        Location visit2 = new Location(2, Coordinates.of(22.0, 33.0), "Visit 2");
         Vehicle vehicle1 = VehicleFactory.createVehicle(11, "Vehicle 1", 100);
         Vehicle vehicle2 = VehicleFactory.createVehicle(12, "Vehicle 2", 200);
         when(locationRepository.locations()).thenReturn(Arrays.asList(depot, visit1, visit2));

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemListTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/RoutingProblemListTest.java
@@ -51,7 +51,7 @@ class RoutingProblemListTest {
     @Test
     void all_by_name_should_return_expected_problems() {
         List<VehicleData> vehicles = Collections.emptyList();
-        Location depot = new Location(0, Coordinates.valueOf(10, -20));
+        Location depot = new Location(0, Coordinates.of(10, -20));
         List<Location> visits = Collections.emptyList();
         String name1 = "Problem A";
         String name2 = "Problem B";

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshallerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/demo/dataset/DataSetMarshallerTest.java
@@ -119,22 +119,22 @@ class DataSetMarshallerTest {
         String description = "some location";
 
         // domain -> data set
-        DataSetLocation dataSetLocation = toDataSet(new LocationData(Coordinates.valueOf(lat, lng), description));
+        DataSetLocation dataSetLocation = toDataSet(new LocationData(Coordinates.of(lat, lng), description));
         assertThat(dataSetLocation.getLatitude()).isEqualTo(lat);
         assertThat(dataSetLocation.getLongitude()).isEqualTo(lng);
         assertThat(dataSetLocation.getLabel()).isEqualTo(description);
 
         // data set -> domain
         LocationData location = toDomain(dataSetLocation);
-        assertThat(location).isEqualTo(new LocationData(Coordinates.valueOf(lat, lng), description));
+        assertThat(location).isEqualTo(new LocationData(Coordinates.of(lat, lng), description));
     }
 
     @Test
     void routing_problem_conversion() {
         VehicleData vehicle = VehicleFactory.vehicleData("vehicle", 10);
         List<VehicleData> vehicles = Arrays.asList(vehicle);
-        LocationData depot = new LocationData(Coordinates.valueOf(60.1, 5.78), "Depot");
-        LocationData visit = new LocationData(Coordinates.valueOf(1.06, 8.75), "Visit");
+        LocationData depot = new LocationData(Coordinates.of(60.1, 5.78), "Depot");
+        LocationData visit = new LocationData(Coordinates.of(1.06, 8.75), "Visit");
         List<LocationData> visits = Arrays.asList(visit);
         String name = "some data set";
 

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceIntegrationTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceIntegrationTest.java
@@ -44,9 +44,9 @@ class LocationServiceIntegrationTest {
     void location_service_should_be_transactional() {
         when(distanceMatrix.addLocation(any())).thenReturn(locationId -> Distance.ZERO);
         when(distanceMatrix.distance(any(), any())).thenReturn(Distance.ZERO);
-        locationService.addLocation(new Location(1000, Coordinates.valueOf(-1, 12)));
-        locationService.createLocation(Coordinates.valueOf(12, -1), "location 1");
-        Optional<Location> location = locationService.createLocation(Coordinates.valueOf(32, -5), "location 2");
+        locationService.addLocation(new Location(1000, Coordinates.of(-1, 12)));
+        locationService.createLocation(Coordinates.of(12, -1), "location 1");
+        Optional<Location> location = locationService.createLocation(Coordinates.of(32, -5), "location 2");
         assertThat(location).isNotEmpty();
         locationService.populateDistanceMatrix();
         locationService.removeLocation(location.get().id());

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
@@ -60,7 +60,7 @@ class LocationServiceTest {
     @InjectMocks
     private LocationService locationService;
 
-    private final Coordinates coordinates = Coordinates.valueOf(0.0, 1.0);
+    private final Coordinates coordinates = Coordinates.of(0.0, 1.0);
     private final Location location = new Location(1, coordinates);
 
     @Test

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/region/BoundingBoxTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/region/BoundingBoxTest.java
@@ -31,22 +31,22 @@ class BoundingBoxTest {
         // │ ↘ │
         // └───2
         assertThatIllegalArgumentException().isThrownBy(() -> new BoundingBox(
-                Coordinates.valueOf(9.9, -1.0), // NW
-                Coordinates.valueOf(1.0, 1.01) // SE
+                Coordinates.of(9.9, -1.0), // NW
+                Coordinates.of(1.0, 1.01) // SE
         )).withMessageMatching(".*\\(9\\.9N.*\\(1\\.0N.*");
         // 2───┐
         // │ ↖ │
         // └───1
         assertThatIllegalArgumentException().isThrownBy(() -> new BoundingBox(
-                Coordinates.valueOf(-1.0, 9.9), // SE
-                Coordinates.valueOf(1.01, 1.0) // NW
+                Coordinates.of(-1.0, 9.9), // SE
+                Coordinates.of(1.01, 1.0) // NW
         )).withMessageMatching(".*\\(9\\.9E.*\\(1\\.0E.*");
         // ┌───1
         // │ ↙ │
         // 2───┘
         assertThatIllegalArgumentException().isThrownBy(() -> new BoundingBox(
-                Coordinates.valueOf(9.9, 9.9), // NE
-                Coordinates.valueOf(1.0, 1.0) // SW
+                Coordinates.of(9.9, 9.9), // NE
+                Coordinates.of(1.0, 1.0) // SW
         )).withMessageMatching(".*\\(9\\.9N.*\\(1\\.0N.*");
     }
 
@@ -56,20 +56,20 @@ class BoundingBoxTest {
         // ╶───╴
         //
         assertThatIllegalArgumentException().isThrownBy(() -> new BoundingBox(
-                Coordinates.valueOf(0.0, 1.0),
-                Coordinates.valueOf(0.0, 2.0))).withMessageMatching(".*\\(0\\.0N.*\\(0\\.0N.*");
+                Coordinates.of(0.0, 1.0),
+                Coordinates.of(0.0, 2.0))).withMessageMatching(".*\\(0\\.0N.*\\(0\\.0N.*");
         //   ╷
         //   │
         //   ╵
         assertThatIllegalArgumentException().isThrownBy(() -> new BoundingBox(
-                Coordinates.valueOf(0.0, 10.0),
-                Coordinates.valueOf(1.0, 10.0))).withMessageMatching(".*\\(10\\.0E.*\\(10\\.0E.*");
+                Coordinates.of(0.0, 10.0),
+                Coordinates.of(1.0, 10.0))).withMessageMatching(".*\\(10\\.0E.*\\(10\\.0E.*");
     }
 
     @Test
     void constructor_args_not_null() {
-        assertThatNullPointerException().isThrownBy(() -> new BoundingBox(null, Coordinates.valueOf(1.0, 1.0)));
-        assertThatNullPointerException().isThrownBy(() -> new BoundingBox(Coordinates.valueOf(1.0, 1.0), null));
+        assertThatNullPointerException().isThrownBy(() -> new BoundingBox(null, Coordinates.of(1.0, 1.0)));
+        assertThatNullPointerException().isThrownBy(() -> new BoundingBox(Coordinates.of(1.0, 1.0), null));
     }
 
     @Test
@@ -77,8 +77,8 @@ class BoundingBoxTest {
         // ┌───2
         // │ ↗ │
         // 1───┘
-        Coordinates sw = Coordinates.valueOf(-10.0, -100.0);
-        Coordinates ne = Coordinates.valueOf(20.0, -2.0);
+        Coordinates sw = Coordinates.of(-10.0, -100.0);
+        Coordinates ne = Coordinates.of(20.0, -2.0);
         BoundingBox boundingBox = new BoundingBox(sw, ne);
         assertThat(boundingBox.getSouthWest()).isEqualTo(sw);
         assertThat(boundingBox.getNorthEast()).isEqualTo(ne);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/reload/ReloadServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/reload/ReloadServiceTest.java
@@ -58,8 +58,7 @@ class ReloadServiceTest {
 
     private final Vehicle vehicle = VehicleFactory.createVehicle(193, "Vehicle 193", 100);
     private final List<Vehicle> persistedVehicles = Arrays.asList(vehicle, vehicle);
-    private final Coordinates coordinates = Coordinates.valueOf(0.0, 1.0);
-    private final Location location = new Location(1, coordinates);
+    private final Location location = new Location(1, Coordinates.of(0.0, 1.0));
     private final List<Location> persistedLocations = Arrays.asList(location, location, location);
 
     @Test

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/route/RouteListenerTest.java
@@ -93,7 +93,7 @@ class RouteListenerTest {
 
     @Test
     void event_with_no_visits_and_a_depot_should_be_consumed_as_plan_with_empty_routes() {
-        final Coordinates depotCoordinates = Coordinates.valueOf(0.0, 0.1);
+        final Coordinates depotCoordinates = Coordinates.of(0.0, 0.1);
         final Location depot = new Location(1, depotCoordinates);
         final long vehicleId = 448;
         final Vehicle vehicle = VehicleFactory.testVehicle(vehicleId);
@@ -126,10 +126,10 @@ class RouteListenerTest {
 
     @Test
     void listener_should_pass_routing_plan_to_consumer_when_an_update_event_occurs() {
-        final Coordinates depotCoordinates = Coordinates.valueOf(0.0, 0.1);
-        final Coordinates visitCoordinates = Coordinates.valueOf(2.0, -0.2);
-        final Coordinates checkpoint1 = Coordinates.valueOf(12, 12);
-        final Coordinates checkpoint2 = Coordinates.valueOf(21, 21);
+        final Coordinates depotCoordinates = Coordinates.of(0.0, 0.1);
+        final Coordinates visitCoordinates = Coordinates.of(2.0, -0.2);
+        final Coordinates checkpoint1 = Coordinates.of(12, 12);
+        final Coordinates checkpoint2 = Coordinates.of(21, 21);
         List<Coordinates> path1 = Arrays.asList(depotCoordinates, checkpoint1, checkpoint2, visitCoordinates);
         List<Coordinates> path2 = Arrays.asList(visitCoordinates, checkpoint2, checkpoint1, depotCoordinates);
         when(router.getPath(depotCoordinates, visitCoordinates)).thenReturn(path1);
@@ -173,8 +173,8 @@ class RouteListenerTest {
     @Test
     void should_discard_update_gracefully_if_one_of_the_locations_no_longer_exist() {
         final Vehicle vehicle = VehicleFactory.testVehicle(3);
-        final Location depot = new Location(1, Coordinates.valueOf(1.0, 2.0));
-        final Location visit = new Location(2, Coordinates.valueOf(-1.0, -2.0));
+        final Location depot = new Location(1, Coordinates.of(1.0, 2.0));
+        final Location visit = new Location(2, Coordinates.of(-1.0, -2.0));
         when(vehicleRepository.find(vehicle.id())).thenReturn(Optional.of(vehicle));
         when(locationRepository.find(depot.id())).thenReturn(Optional.of(depot));
         when(locationRepository.find(visit.id())).thenReturn(Optional.empty());
@@ -203,8 +203,8 @@ class RouteListenerTest {
     @Test
     void should_discard_update_gracefully_if_one_of_the_vehicles_no_longer_exist() {
         final Vehicle vehicle = VehicleFactory.testVehicle(3);
-        final Location depot = new Location(1, Coordinates.valueOf(1.0, 2.0));
-        final Location visit = new Location(2, Coordinates.valueOf(-1.0, -2.0));
+        final Location depot = new Location(1, Coordinates.of(1.0, 2.0));
+        final Location visit = new Location(2, Coordinates.of(-1.0, -2.0));
         when(vehicleRepository.find(vehicle.id())).thenReturn(Optional.empty());
         when(locationRepository.find(depot.id())).thenReturn(Optional.of(depot));
 


### PR DESCRIPTION
Improve the code's ability to be read like a prose.

Align with the naming convention utilized by some recent Java APIs (`Stream.of()`, `Optional.of()`, `List.of()`, ...) and OptaPlanner's `*Score.of()`.

Supported by J. Bloch's definition from Effective Java, 3rd edition:
> of—An aggregation method that takes multiple parameters and returns an instance of this type that incorporates them


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
</details>
