### PR TITLE
Bump Quarkus 2.3.0.Final

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application.properties
@@ -51,9 +51,9 @@ quarkus.log.category."org.jboss.resteasy".level=${LOG_LEVEL_RESTEASY:INFO}
 
 # [Production]
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME}
-quarkus.datasource.username=${DATABASE_USER}
-quarkus.datasource.password=${DATABASE_PASSWORD}
+quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
+quarkus.datasource.username=${DATABASE_USER:sa}
+quarkus.datasource.password=${DATABASE_PASSWORD:}
 quarkus.hibernate-orm.database.generation=update
 # [Development]
 # - using an embedded DB with relative path: http://h2database.com/html/features.html#embedded_databases

--- a/optaweb-vehicle-routing-standalone/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-standalone/src/main/resources/application.properties
@@ -35,8 +35,8 @@ quarkus.hibernate-orm.database.generation=update
 
 %postgres.quarkus.datasource.db-kind=postgresql
 %postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
-%postgres.quarkus.datasource.username=${DATABASE_USER}
-%postgres.quarkus.datasource.password=${DATABASE_PASSWORD}
+%postgres.quarkus.datasource.username=${DATABASE_USER:sa}
+%postgres.quarkus.datasource.password=${DATABASE_PASSWORD:}
 %postgres.quarkus.hibernate-orm.database.generation=update
 
 %cypress.app.region.country-codes=DE


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1634
- https://github.com/kiegroup/optaplanner/pull/1593
- https://github.com/kiegroup/kogito-apps/pull/1044
- https://github.com/kiegroup/kogito-examples/pull/909
- https://github.com/kiegroup/optaplanner-quickstarts/pull/190
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/570


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
</details>
