### PR TITLE
Move PostgreSQL config to the postgres profile

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application.properties
@@ -49,20 +49,22 @@ quarkus.log.category."org.jboss.resteasy".level=${LOG_LEVEL_RESTEASY:INFO}
 # Datasource
 ############
 
-# [Production]
-quarkus.datasource.db-kind=postgresql
-quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME}
-quarkus.datasource.username=${DATABASE_USER}
-quarkus.datasource.password=${DATABASE_PASSWORD}
-quarkus.hibernate-orm.database.generation=update
-# [Development]
+# [Postgres] - recommended for production
+%postgres.quarkus.datasource.db-kind=postgresql
+%postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
+%postgres.quarkus.datasource.username=${DATABASE_USER}
+%postgres.quarkus.datasource.password=${DATABASE_PASSWORD}
+%postgres.quarkus.hibernate-orm.database.generation=update
+
+# [Default] - works out of the box, good for development
 # - using an embedded DB with relative path: http://h2database.com/html/features.html#embedded_databases
 # - not closing the DB automatically: http://h2database.com/html/features.html#closing_a_database
-%dev.quarkus.datasource.db-kind=h2
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:file:${app.persistence.h2-dir:../local/db}/${app.persistence.h2-filename:vrp};DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
-%dev.quarkus.datasource.username=sa
-%dev.quarkus.datasource.password=
-%dev.quarkus.hibernate-orm.database.generation=update
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:file:${app.persistence.h2-dir:../local/db}/${app.persistence.h2-filename:optaweb_vrp_database};DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
+quarkus.datasource.username=sa
+quarkus.datasource.password=
+quarkus.hibernate-orm.database.generation=update
+
 # [Tests]
 # - using an in-memory DB: http://h2database.com/html/features.html#in_memory_databases
 # - not closing the DB automatically: http://h2database.com/html/features.html#closing_a_database


### PR DESCRIPTION
This is needed for upgrading to Quarkus 2.3.0 where the datasource is
created more strictly and it fails in build time if the DATABASE_USER
property is not set.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
</details>
