### PR TITLE
Mock Nominatim API in the Cypress test

### DIFF
--- a/optaweb-vehicle-routing-frontend/cypress/fixtures/response-garz.json
+++ b/optaweb-vehicle-routing-frontend/cypress/fixtures/response-garz.json
@@ -1,0 +1,21 @@
+[
+  {
+    "place_id": 1243027,
+    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+    "osm_type": "node",
+    "osm_id": 311384628,
+    "boundingbox": [
+      "53.0183353",
+      "53.0583353",
+      "12.0651506",
+      "12.1051506"
+    ],
+    "lat": "53.0383353",
+    "lon": "12.0851506",
+    "display_name": "Garz, Hoppenrade, Plattenburg, Prignitz, Brandenburg, Germany",
+    "class": "place",
+    "type": "hamlet",
+    "importance": 0.35,
+    "icon": "https://nominatim.openstreetmap.org/ui/mapicons//poi_place_village.p.20.png"
+  }
+]

--- a/optaweb-vehicle-routing-frontend/cypress/fixtures/response-hoppenrade.json
+++ b/optaweb-vehicle-routing-frontend/cypress/fixtures/response-hoppenrade.json
@@ -1,0 +1,40 @@
+[
+  {
+    "place_id": 283087710,
+    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+    "osm_type": "relation",
+    "osm_id": 9656282,
+    "boundingbox": [
+      "53.0147994",
+      "53.0556191",
+      "12.0157931",
+      "12.1143161"
+    ],
+    "lat": "53.03502605",
+    "lon": "12.069659320997278",
+    "display_name": "Hoppenrade, Plattenburg, Prignitz, Brandenburg, Germany",
+    "class": "boundary",
+    "type": "administrative",
+    "importance": 0.4,
+    "icon": "https://nominatim.openstreetmap.org/ui/mapicons//poi_boundary_administrative.p.20.png"
+  },
+  {
+    "place_id": 536362,
+    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+    "osm_type": "node",
+    "osm_id": 240025900,
+    "boundingbox": [
+      "53.019054",
+      "53.059054",
+      "12.042413",
+      "12.082413"
+    ],
+    "lat": "53.039054",
+    "lon": "12.062413",
+    "display_name": "Hoppenrade, Plattenburg, Prignitz, Brandenburg, 19339, Germany",
+    "class": "place",
+    "type": "hamlet",
+    "importance": 0.35,
+    "icon": "https://nominatim.openstreetmap.org/ui/mapicons//poi_place_village.p.20.png"
+  }
+]

--- a/optaweb-vehicle-routing-frontend/cypress/integration/fromLocationsToRoute.js
+++ b/optaweb-vehicle-routing-frontend/cypress/integration/fromLocationsToRoute.js
@@ -15,6 +15,8 @@
  */
 
 describe('Locations can be added and route is computed', () => {
+  const cities = ['Garz', 'Hoppenrade'];
+
   /**
    * Adds a location by searching for a city of a given name.
    * @param { string } name - city name
@@ -45,13 +47,16 @@ describe('Locations can be added and route is computed', () => {
 
   before(() => {
     cy.intercept('POST', '**/api/clear').as('postClear');
+    cities.forEach((city) => cy.intercept(
+      'GET',
+      `https://nominatim.openstreetmap.org/search?*q=${city}`,
+      { fixture: `response-${city.toLowerCase()}.json` },
+    ));
     visitDemo();
     clearLocations();
   });
 
   it('Locations added via clicking on a map are added to a route', () => {
-    const cities = ['Garz', 'Hoppenrade'];
-
     cities.forEach((city) => {
       addCity(city);
     });


### PR DESCRIPTION
This E2E test uses the geosearch feature (looking up coordinates for a given address). The app uses https://nominatim.openstreetmap.org, which is a public online service. It has downtimes and that hurts the test stability. Fortunately, it's easy to mock its API and return the same cached response without contacting the service during the test.

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
</details>
