### PR TITLE
PLANNER-2560: Use forEach instead of from in constraints

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/VehicleRoutingConstraintProvider.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/VehicleRoutingConstraintProvider.java
@@ -36,7 +36,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
     }
 
     Constraint vehicleCapacity(ConstraintFactory constraintFactory) {
-        return constraintFactory.from(PlanningVisit.class)
+        return constraintFactory.forEach(PlanningVisit.class)
                 .groupBy(PlanningVisit::getVehicle, sum(PlanningVisit::getDemand))
                 .filter((vehicle, demand) -> demand > vehicle.getCapacity())
                 .penalizeLong(
@@ -46,7 +46,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
     }
 
     Constraint distanceFromPreviousStandstill(ConstraintFactory constraintFactory) {
-        return constraintFactory.from(PlanningVisit.class)
+        return constraintFactory.forEach(PlanningVisit.class)
                 .penalizeLong(
                         "distance from previous standstill",
                         HardSoftLongScore.ONE_SOFT,
@@ -54,7 +54,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
     }
 
     Constraint distanceFromLastVisitToDepot(ConstraintFactory constraintFactory) {
-        return constraintFactory.from(PlanningVisit.class)
+        return constraintFactory.forEach(PlanningVisit.class)
                 .filter(PlanningVisit::isLast)
                 .penalizeLong(
                         "distance from last visit to depot",


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2560

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
</details>
