### PR TITLE
[8.11.x] BXMSPROD-1542 definition-file eval expression

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,9 +42,7 @@ jobs:
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.18
         with:
-          # OptaWeb has a different branching model than the rest of KIE. Every OptaWeb 8.x branch maps to main branch
-          # in KIE, therefore "main" is hard-coded in the URL below. Once the branching model is unified and there is
-          # a matching branch in KIE for each 8.x (or higher) branch in OptaWeb, replace "main" with "${BRANCH}".
+          # Opta* and drools* projects have a different branching model than kogito projects. Every Opta* and drools* X.Y.Z branch maps to X-7.Y.Z branch
           definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/%{process.env.GITHUB_BASE_REF.replace(/(\d*)\.(.*)\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,46 +5,35 @@ on: [pull_request]
 jobs:
   build-chain:
     concurrency:
-      group: pull_request-${{ github.head_ref }}
+      group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}      
       cancel-in-progress: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java-version: [11]
+        java-version: [11, 17]
         maven-version: ['3.8.1']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Maven Build
     steps:
-      - name: Support longpaths
+      - name: Clean Disk Space
+        uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@main
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Support long paths
         if: ${{ matrix.os == 'windows-latest' }}
-        run: git config --system core.longpaths true
-      - name: Free disk space
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          df -h
-          sudo rm -rf /usr/local/lib/android
-          docker rmi $(docker image ls -aq)
-          df -h
-      - name: Setup Maven And Java Version
-        uses: s4u/setup-maven-action@v1.2.1
+        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@main
+      - name: Java and Maven Setup
+        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
-      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
-      - name: Cache Maven packages
-        uses: actions/cache@v2
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+      - name: Build Chain
+        uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@main
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
-      - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
-        id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.4
-        with:
-          # OptaWeb has a different branching model than the rest of KIE. Every OptaWeb 8.x branch maps to main branch
-          # in KIE, therefore "main" is hard-coded in the URL below. Once the branching model is unified and there is
-          # a matching branch in KIE for each 8.x (or higher) branch in OptaWeb, replace "main" with "${BRANCH}".
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/%{process.env.GITHUB_BASE_REF.replace(/(\d*)\.(.*)\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)}/.ci/pull-request-config.yaml
+          annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Surefire Report
+        uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@main
+        if: ${{ always() }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,35 +5,47 @@ on: [pull_request]
 jobs:
   build-chain:
     concurrency:
-      group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}      
+      group: pull_request-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java-version: [11, 17]
+        java-version: [11]
         maven-version: ['3.8.1']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Maven Build
     steps:
-      - name: Clean Disk Space
-        uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@main
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-      - name: Support long paths
+      - name: Support longpaths
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@main
-      - name: Java and Maven Setup
-        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
+        run: git config --system core.longpaths true
+      - name: Free disk space
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          docker rmi $(docker image ls -aq)
+          df -h
+      - name: Setup Maven And Java Version
+        uses: s4u/setup-maven-action@v1.2.1
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
-          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
-      - name: Build Chain
-        uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@main
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
         with:
+          path: ~/.m2
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
+      - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
+        id: build-chain
+        uses: kiegroup/github-action-build-chain@v2.6.18
+        with:
+          # OptaWeb has a different branching model than the rest of KIE. Every OptaWeb 8.x branch maps to main branch
+          # in KIE, therefore "main" is hard-coded in the URL below. Once the branching model is unified and there is
+          # a matching branch in KIE for each 8.x (or higher) branch in OptaWeb, replace "main" with "${BRANCH}".
           definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/%{process.env.GITHUB_BASE_REF.replace(/(\d*)\.(.*)\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Surefire Report
-        uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@main
-        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/BXMSPROD-1542

### Referenced pull requests

- https://github.com/kiegroup/optaweb-vehicle-routing/pull/603
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/602

I will propagate the change to drools, droolsjbpm-knowledge, and opta* projects as soon as we agree on the change

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
</details>
