### PR TITLE
[7.x] Add a check that fails if there are any uncommitted changes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,3 +50,9 @@ jobs:
       - name: Surefire Report
         uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/surefire-report@main
         if: ${{ always() }}
+      - name: Check uncommitted changes
+        if: ${{ always() }}
+        # Check that Git working tree is clean after running `npm install` via the frontend-maven-plugin.
+        # The `git` command exits with 1 and fails the build if there are any uncommitted changes.
+        run: git diff HEAD --exit-code
+        working-directory: kiegroup_optaweb_vehicle_routing


### PR DESCRIPTION
This PR adds a step that fails if there are any uncommitted changes in the Git working tree of `optaweb-vehicle-routing` after running the Maven build. The goal is to detect PRs where changes to `package.json` in `optaweb-vehicle-routing-frontend` are made without reflecting that in `package-lock.json`.

The `package-lock.json` must be always perfectly in sync with `package.json` to:
- Ensure build stability (CI and other developers use exactly the same dependencies as the author who last updated `package.json`).
- Avoid merge conflicts on `pacakge-lock.json`.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>
