### PR TITLE
PLANNER-2541 Simplify ProblemFactChange interface

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolverManager.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/SolverManager.java
@@ -87,7 +87,7 @@ class SolverManager implements SolverEventListener<VehicleRoutingSolution> {
         // CAUTION! This runs on the solver thread. Implications:
         // 1. The method should be as quick as possible to avoid blocking solver unnecessarily.
         // 2. This place is a potential source of race conditions.
-        if (!bestSolutionChangedEvent.isEveryProblemFactChangeProcessed()) {
+        if (!bestSolutionChangedEvent.isEveryProblemChangeProcessed()) {
             logger.info("Ignoring a new best solution that has some problem facts missing");
             return;
         }
@@ -171,27 +171,27 @@ class SolverManager implements SolverEventListener<VehicleRoutingSolution> {
 
     void addVisit(PlanningVisit visit) {
         assertSolverIsAlive();
-        solver.addProblemFactChange(new AddVisit(visit));
+        solver.addProblemChange(new AddVisit(visit));
     }
 
     void removeVisit(PlanningVisit visit) {
         assertSolverIsAlive();
-        solver.addProblemFactChange(new RemoveVisit(visit));
+        solver.addProblemChange(new RemoveVisit(visit));
     }
 
     void addVehicle(PlanningVehicle vehicle) {
         assertSolverIsAlive();
-        solver.addProblemFactChange(new AddVehicle(vehicle));
+        solver.addProblemChange(new AddVehicle(vehicle));
     }
 
     void removeVehicle(PlanningVehicle vehicle) {
         assertSolverIsAlive();
-        solver.addProblemFactChange(new RemoveVehicle(vehicle));
+        solver.addProblemChange(new RemoveVehicle(vehicle));
     }
 
     void changeCapacity(PlanningVehicle vehicle) {
         assertSolverIsAlive();
-        solver.addProblemFactChange(new ChangeVehicleCapacity(vehicle));
+        solver.addProblemChange(new ChangeVehicleCapacity(vehicle));
     }
 
     /**

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicle.java
@@ -18,12 +18,12 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.api.solver.ProblemFactChange;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-public class AddVehicle implements ProblemFactChange<VehicleRoutingSolution> {
+public class AddVehicle implements ProblemChange<VehicleRoutingSolution> {
 
     private final PlanningVehicle vehicle;
 
@@ -32,11 +32,7 @@ public class AddVehicle implements ProblemFactChange<VehicleRoutingSolution> {
     }
 
     @Override
-    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
-        scoreDirector.beforeProblemFactAdded(vehicle);
-        scoreDirector.getWorkingSolution().getVehicleList().add(vehicle);
-        scoreDirector.afterProblemFactAdded(vehicle);
-
-        scoreDirector.triggerVariableListeners();
+    public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
+        problemChangeDirector.addProblemFact(vehicle, workingSolution.getVehicleList()::add);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVisit.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVisit.java
@@ -18,12 +18,12 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.api.solver.ProblemFactChange;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-public class AddVisit implements ProblemFactChange<VehicleRoutingSolution> {
+public class AddVisit implements ProblemChange<VehicleRoutingSolution> {
 
     private final PlanningVisit visit;
 
@@ -32,11 +32,7 @@ public class AddVisit implements ProblemFactChange<VehicleRoutingSolution> {
     }
 
     @Override
-    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
-        scoreDirector.beforeEntityAdded(visit);
-        scoreDirector.getWorkingSolution().getVisitList().add(visit);
-        scoreDirector.afterEntityAdded(visit);
-
-        scoreDirector.triggerVariableListeners();
+    public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
+        problemChangeDirector.addEntity(visit, workingSolution.getVisitList()::add);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/ChangeVehicleCapacity.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/ChangeVehicleCapacity.java
@@ -18,12 +18,12 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.api.solver.ProblemFactChange;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-public class ChangeVehicleCapacity implements ProblemFactChange<VehicleRoutingSolution> {
+public class ChangeVehicleCapacity implements ProblemChange<VehicleRoutingSolution> {
 
     private final PlanningVehicle vehicle;
 
@@ -32,20 +32,11 @@ public class ChangeVehicleCapacity implements ProblemFactChange<VehicleRoutingSo
     }
 
     @Override
-    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
-        PlanningVehicle workingVehicle = scoreDirector.lookUpWorkingObject(vehicle);
-        if (workingVehicle == null) {
-            throw new IllegalStateException("Can't look up a working copy of " + vehicle);
-        }
-
+    public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
         // No need to clone the workingVehicle because it is a planning entity, so it is already planning-cloned.
         // To learn more about problem fact changes, see:
-        // https://docs.jboss.org/optaplanner/release/latest/optaplanner-docs/html_single/#problemFactChangeExample
-
-        scoreDirector.beforeProblemPropertyChanged(workingVehicle);
-        workingVehicle.setCapacity(vehicle.getCapacity());
-        scoreDirector.afterProblemPropertyChanged(workingVehicle);
-
-        scoreDirector.triggerVariableListeners();
+        // https://www.optaplanner.org/docs/optaplanner/latest/repeated-planning/repeated-planning.html#problemChangeExample
+        problemChangeDirector.changeProblemProperty(vehicle,
+                workingVehicle -> workingVehicle.setCapacity(vehicle.getCapacity()));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
@@ -36,9 +36,6 @@ public class RemoveVehicle implements ProblemChange<VehicleRoutingSolution> {
     public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
         // Look up a working copy of the vehicle
         PlanningVehicle workingVehicle = problemChangeDirector.lookUpWorkingObject(removedVehicle);
-        if (workingVehicle == null) {
-            throw new IllegalStateException("Can't look up a working copy of " + removedVehicle);
-        }
 
         // Un-initialize all visits of this vehicle
         for (PlanningVisit visit : workingVehicle.getFutureVisits()) {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
@@ -18,13 +18,13 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.api.solver.ProblemFactChange;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-public class RemoveVehicle implements ProblemFactChange<VehicleRoutingSolution> {
+public class RemoveVehicle implements ProblemChange<VehicleRoutingSolution> {
 
     private final PlanningVehicle removedVehicle;
 
@@ -33,39 +33,34 @@ public class RemoveVehicle implements ProblemFactChange<VehicleRoutingSolution> 
     }
 
     @Override
-    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
-        VehicleRoutingSolution workingSolution = scoreDirector.getWorkingSolution();
-
+    public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
         // Look up a working copy of the vehicle
-        PlanningVehicle workingVehicle = scoreDirector.lookUpWorkingObject(removedVehicle);
+        PlanningVehicle workingVehicle = problemChangeDirector.lookUpWorkingObject(removedVehicle);
         if (workingVehicle == null) {
             throw new IllegalStateException("Can't look up a working copy of " + removedVehicle);
         }
 
         // Un-initialize all visits of this vehicle
         for (PlanningVisit visit : workingVehicle.getFutureVisits()) {
-            scoreDirector.beforeVariableChanged(visit, "previousStandstill");
-            visit.setPreviousStandstill(null);
-            scoreDirector.afterVariableChanged(visit, "previousStandstill");
+            problemChangeDirector.changeVariable(visit, "previousStandstill",
+                    planningVisit -> planningVisit.setPreviousStandstill(null));
         }
 
         // No need to clone the vehicleList because it is a planning entity collection, so it is already
         // planning-cloned.
         // To learn more about problem fact changes, see:
-        // https://docs.jboss.org/optaplanner/release/latest/optaplanner-docs/html_single/#problemFactChangeExample
+        // https://www.optaplanner.org/docs/optaplanner/latest/repeated-planning/repeated-planning.html#problemChangeExample
 
         // Remove the vehicle
-        scoreDirector.beforeProblemFactRemoved(workingVehicle);
-        if (!workingSolution.getVehicleList().remove(workingVehicle)) {
-            throw new IllegalStateException(
-                    "Working solution's vehicleList "
-                            + workingSolution.getVehicleList()
-                            + " doesn't contain the workingVehicle ("
-                            + workingVehicle
-                            + "). This is a bug!");
-        }
-        scoreDirector.afterProblemFactRemoved(workingVehicle);
-
-        scoreDirector.triggerVariableListeners();
+        problemChangeDirector.removeProblemFact(workingVehicle, planningVehicle -> {
+            if (!workingSolution.getVehicleList().remove(planningVehicle)) {
+                throw new IllegalStateException(
+                        "Working solution's vehicleList "
+                                + workingSolution.getVehicleList()
+                                + " doesn't contain the workingVehicle ("
+                                + planningVehicle
+                                + "). This is a bug!");
+            }
+        });
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicle.java
@@ -35,7 +35,7 @@ public class RemoveVehicle implements ProblemChange<VehicleRoutingSolution> {
     @Override
     public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
         // Look up a working copy of the vehicle
-        PlanningVehicle workingVehicle = problemChangeDirector.lookUpWorkingObject(removedVehicle);
+        PlanningVehicle workingVehicle = problemChangeDirector.lookUpWorkingObjectOrFail(removedVehicle);
 
         // Un-initialize all visits of this vehicle
         for (PlanningVisit visit : workingVehicle.getFutureVisits()) {

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVisit.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVisit.java
@@ -34,7 +34,7 @@ public class RemoveVisit implements ProblemChange<VehicleRoutingSolution> {
     @Override
     public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
         // Look up a working copy of the visit
-        PlanningVisit workingVisit = problemChangeDirector.lookUpWorkingObject(planningVisit);
+        PlanningVisit workingVisit = problemChangeDirector.lookUpWorkingObjectOrFail(planningVisit);
 
         // Fix the next visit and set its previousStandstill to the removed visit's previousStandstill
         PlanningVisit nextVisit = workingVisit.getNextVisit();

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVisit.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVisit.java
@@ -18,12 +18,12 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import java.util.Objects;
 
-import org.optaplanner.core.api.score.director.ScoreDirector;
-import org.optaplanner.core.api.solver.ProblemFactChange;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-public class RemoveVisit implements ProblemFactChange<VehicleRoutingSolution> {
+public class RemoveVisit implements ProblemChange<VehicleRoutingSolution> {
 
     private final PlanningVisit planningVisit;
 
@@ -32,39 +32,31 @@ public class RemoveVisit implements ProblemFactChange<VehicleRoutingSolution> {
     }
 
     @Override
-    public void doChange(ScoreDirector<VehicleRoutingSolution> scoreDirector) {
-        VehicleRoutingSolution workingSolution = scoreDirector.getWorkingSolution();
-
+    public void doChange(VehicleRoutingSolution workingSolution, ProblemChangeDirector problemChangeDirector) {
         // Look up a working copy of the visit
-        PlanningVisit workingVisit = scoreDirector.lookUpWorkingObject(planningVisit);
-        if (workingVisit == null) {
-            throw new IllegalStateException("Can't look up a working copy of " + planningVisit);
-        }
+        PlanningVisit workingVisit = problemChangeDirector.lookUpWorkingObject(planningVisit);
 
         // Fix the next visit and set its previousStandstill to the removed visit's previousStandstill
         PlanningVisit nextVisit = workingVisit.getNextVisit();
         if (nextVisit != null) { // otherwise it's the last visit
-            scoreDirector.beforeVariableChanged(nextVisit, "previousStandstill");
-            nextVisit.setPreviousStandstill(workingVisit.getPreviousStandstill());
-            scoreDirector.afterVariableChanged(nextVisit, "previousStandstill");
+            problemChangeDirector.changeVariable(nextVisit, "previousStandstill",
+                    workingNextVisit -> workingNextVisit.setPreviousStandstill(workingVisit.getPreviousStandstill()));
         }
 
         // No need to clone the visitList because it is a planning entity collection, so it is already planning-cloned.
         // To learn more about problem fact changes, see:
-        // https://docs.jboss.org/optaplanner/release/latest/optaplanner-docs/html_single/#problemFactChangeExample
+        // https://www.optaplanner.org/docs/optaplanner/latest/repeated-planning/repeated-planning.html#problemChangeExample
 
         // Remove the visit
-        scoreDirector.beforeEntityRemoved(workingVisit);
-        if (!workingSolution.getVisitList().remove(workingVisit)) {
-            throw new IllegalStateException(
-                    "Working solution's visitList "
-                            + workingSolution.getVisitList()
-                            + " doesn't contain the workingVisit ("
-                            + workingVisit
-                            + "). This is a bug!");
-        }
-        scoreDirector.afterEntityRemoved(workingVisit);
-
-        scoreDirector.triggerVariableListeners();
+        problemChangeDirector.removeEntity(planningVisit, visit -> {
+            if (!workingSolution.getVisitList().remove(visit)) {
+                throw new IllegalStateException(
+                        "Working solution's visitList "
+                                + workingSolution.getVisitList()
+                                + " doesn't contain the workingVisit ("
+                                + visit
+                                + "). This is a bug!");
+            }
+        });
     }
 }

--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/package-info.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/planner/change/package-info.java
@@ -15,10 +15,10 @@
  */
 
 /**
- * {@link org.optaplanner.core.api.solver.ProblemFactChange} implementations.
+ * {@link org.optaplanner.core.api.solver.change.ProblemChange} implementations.
  * <p>
  * Problem fact changes are difficult to write correctly. To understand the code and when implementing new fact changes,
- * read <a href="https://docs.jboss.org/optaplanner/release/latest/optaplanner-docs/html_single/#problemFactChange">
- * ProblemFactChange documentation</a>.
+ * read <a href="https://www.optaplanner.org/docs/optaplanner/latest/repeated-planning/repeated-planning.html#problemChange">
+ * ProblemChange documentation</a>.
  */
 package org.optaweb.vehiclerouting.plugin.planner.change;

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/MockSolver.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/MockSolver.java
@@ -23,26 +23,49 @@ import static org.mockito.Mockito.verify;
 
 import org.mockito.Mockito;
 import org.optaplanner.core.api.solver.change.ProblemChange;
-import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
 import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
 
 public class MockSolver<Solution_> {
 
     private final Solution_ workingSolution;
-    private final ProblemChangeDirector changeDirector;
+    private final MockProblemChangeDirector changeDirector;
 
-    public MockSolver(Solution_ workingSolution, ProblemChangeDirector changeDirector) {
+    public static <Solution_> MockSolver<Solution_> build(Solution_ solution) {
+        MockProblemChangeDirector spy = Mockito.spy(new MockProblemChangeDirector());
+        return new MockSolver<>(solution, spy);
+    }
+
+    private MockSolver(Solution_ workingSolution, MockProblemChangeDirector changeDirector) {
         this.workingSolution = workingSolution;
         this.changeDirector = changeDirector;
     }
+
+    // ************************************************************************
+    // Problem change API from Solver.
+    // ************************************************************************
 
     public void addProblemChange(ProblemChange<Solution_> problemChange) {
         problemChange.doChange(workingSolution, changeDirector);
     }
 
-    public static <Solution_> MockSolver<Solution_> build(Solution_ solution) {
-        MockProblemChangeDirector spy = Mockito.spy(new MockProblemChangeDirector());
-        return new MockSolver<>(solution, spy);
+    // ************************************************************************
+    // Lookup API from MockProblemChangeDirector.
+    // ************************************************************************
+
+    public MockProblemChangeDirector.LookUpMockBuilder whenLookingUp(Object forObject) {
+        return changeDirector.whenLookingUp(forObject);
+    }
+
+    // ************************************************************************
+    // Simplified verification API.
+    // ************************************************************************
+
+    public void verifyEntityAdded(Object entity) {
+        verify(changeDirector).addEntity(same(entity), any());
+    }
+
+    public void verifyEntityRemoved(Object entity) {
+        verify(changeDirector).removeEntity(same(entity), any());
     }
 
     public void verifyVariableChanged(Object entity, String variableName) {
@@ -57,7 +80,7 @@ public class MockSolver<Solution_> {
         verify(changeDirector).removeProblemFact(same(fact), any());
     }
 
-    public void verifyEntityAdded(Object entity) {
-        verify(changeDirector).addEntity(same(entity), any());
+    public void verifyProblemPropertyChanged(Object entityOrFact) {
+        verify(changeDirector).changeProblemProperty(same(entityOrFact), any());
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/MockSolver.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/MockSolver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.vehiclerouting.plugin.planner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+
+import org.mockito.Mockito;
+import org.optaplanner.core.api.solver.change.ProblemChange;
+import org.optaplanner.core.api.solver.change.ProblemChangeDirector;
+import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
+
+public class MockSolver<Solution_> {
+
+    private final Solution_ workingSolution;
+    private final ProblemChangeDirector changeDirector;
+
+    public MockSolver(Solution_ workingSolution, ProblemChangeDirector changeDirector) {
+        this.workingSolution = workingSolution;
+        this.changeDirector = changeDirector;
+    }
+
+    public void addProblemChange(ProblemChange<Solution_> problemChange) {
+        problemChange.doChange(workingSolution, changeDirector);
+    }
+
+    public static <Solution_> MockSolver<Solution_> build(Solution_ solution) {
+        MockProblemChangeDirector spy = Mockito.spy(new MockProblemChangeDirector());
+        return new MockSolver<>(solution, spy);
+    }
+
+    public void verifyVariableChanged(Object entity, String variableName) {
+        verify(changeDirector).changeVariable(same(entity), eq(variableName), any());
+    }
+
+    public void verifyProblemFactAdded(Object fact) {
+        verify(changeDirector).addProblemFact(same(fact), any());
+    }
+
+    public void verifyProblemFactRemoved(Object fact) {
+        verify(changeDirector).removeProblemFact(same(fact), any());
+    }
+
+    public void verifyEntityAdded(Object entity) {
+        verify(changeDirector).addEntity(same(entity), any());
+    }
+}

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
@@ -21,9 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.AdditionalAnswers.answer;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory.testVisit;
 
 import java.util.concurrent.ExecutionException;
@@ -95,7 +93,7 @@ class SolverManagerTest {
     @Test
     void ignore_new_best_solutions_when_unprocessed_fact_changes() {
         // arrange
-        when(bestSolutionChangedEvent.isEveryProblemFactChangeProcessed()).thenReturn(false);
+        when(bestSolutionChangedEvent.isEveryProblemChangeProcessed()).thenReturn(false);
 
         // act
         solverManager.bestSolutionChanged(bestSolutionChangedEvent);
@@ -108,7 +106,7 @@ class SolverManagerTest {
     @Test
     void publish_new_best_solution_if_all_fact_changes_processed() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        when(bestSolutionChangedEvent.isEveryProblemFactChangeProcessed()).thenReturn(true);
+        when(bestSolutionChangedEvent.isEveryProblemChangeProcessed()).thenReturn(true);
         when(bestSolutionChangedEvent.getNewBestSolution()).thenReturn(solution);
 
         solverManager.bestSolutionChanged(bestSolutionChangedEvent);
@@ -211,18 +209,18 @@ class SolverManagerTest {
         when(solverFuture.isDone()).thenReturn(false);
 
         solverManager.addVehicle(testVehicle);
-        verify(solver).addProblemFactChange(any(AddVehicle.class));
+        verify(solver).addProblemChange(any(AddVehicle.class));
 
         solverManager.removeVehicle(testVehicle);
-        verify(solver).addProblemFactChange(any(RemoveVehicle.class));
+        verify(solver).addProblemChange(any(RemoveVehicle.class));
 
         solverManager.changeCapacity(testVehicle);
-        verify(solver).addProblemFactChange(any(ChangeVehicleCapacity.class));
+        verify(solver).addProblemChange(any(ChangeVehicleCapacity.class));
 
         solverManager.addVisit(testVisit);
-        verify(solver).addProblemFactChange(any(AddVisit.class));
+        verify(solver).addProblemChange(any(AddVisit.class));
 
         solverManager.removeVisit(testVisit);
-        verify(solver).addProblemFactChange(any(RemoveVisit.class));
+        verify(solver).addProblemChange(any(RemoveVisit.class));
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/SolverManagerTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.AdditionalAnswers.answer;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory.testVisit;
 
 import java.util.concurrent.ExecutionException;

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicleTest.java
@@ -17,10 +17,9 @@
 package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
+import org.optaweb.vehiclerouting.plugin.planner.MockSolver;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicleFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
@@ -31,14 +30,13 @@ class AddVehicleTest {
     @Test
     void add_vehicle_should_add_vehicle() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
+
+        MockSolver<VehicleRoutingSolution> mockSolver = MockSolver.build(solution);
 
         PlanningVehicle vehicle = PlanningVehicleFactory.testVehicle(1);
-        AddVehicle addVehicle = new AddVehicle(vehicle);
-        addVehicle.doChange(solution, mockProblemChangeDirector);
+        mockSolver.addProblemChange(new AddVehicle(vehicle));
 
         assertThat(solution.getVehicleList()).containsExactly(vehicle);
-
-        verify(mockProblemChangeDirector).addProblemFact(same(vehicle), any());
+        mockSolver.verifyProblemFactAdded(vehicle);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVehicleTest.java
@@ -17,38 +17,28 @@
 package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicleFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-@ExtendWith(MockitoExtension.class)
 class AddVehicleTest {
-
-    @Mock
-    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
 
     @Test
     void add_vehicle_should_add_vehicle() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
 
         PlanningVehicle vehicle = PlanningVehicleFactory.testVehicle(1);
         AddVehicle addVehicle = new AddVehicle(vehicle);
-        addVehicle.doChange(scoreDirector);
+        addVehicle.doChange(solution, mockProblemChangeDirector);
 
         assertThat(solution.getVehicleList()).containsExactly(vehicle);
 
-        verify(scoreDirector).beforeProblemFactAdded(vehicle);
-        verify(scoreDirector).afterProblemFactAdded(vehicle);
-        verify(scoreDirector).triggerVariableListeners();
+        verify(mockProblemChangeDirector).addProblemFact(same(vehicle), any());
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVisitTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVisitTest.java
@@ -17,38 +17,27 @@
 package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-@ExtendWith(MockitoExtension.class)
 class AddVisitTest {
-
-    @Mock
-    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
 
     @Test
     void add_visit_should_add_location_and_create_visit() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
 
         PlanningVisit visit = PlanningVisitFactory.testVisit(1);
         AddVisit addVisit = new AddVisit(visit);
-        addVisit.doChange(scoreDirector);
+        addVisit.doChange(solution, mockProblemChangeDirector);
 
-        verify(scoreDirector).beforeEntityAdded(visit);
-        verify(scoreDirector).afterEntityAdded(visit);
+        verify(mockProblemChangeDirector).addEntity(same(visit), any());
         assertThat(solution.getVisitList()).containsExactly(visit);
-
-        verify(scoreDirector).triggerVariableListeners();
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVisitTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/AddVisitTest.java
@@ -17,10 +17,9 @@
 package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
+import org.optaweb.vehiclerouting.plugin.planner.MockSolver;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
@@ -31,13 +30,12 @@ class AddVisitTest {
     @Test
     void add_visit_should_add_location_and_create_visit() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
+        MockSolver<VehicleRoutingSolution> mockSolver = MockSolver.build(solution);
 
         PlanningVisit visit = PlanningVisitFactory.testVisit(1);
-        AddVisit addVisit = new AddVisit(visit);
-        addVisit.doChange(solution, mockProblemChangeDirector);
+        mockSolver.addProblemChange(new AddVisit(visit));
 
-        verify(mockProblemChangeDirector).addEntity(same(visit), any());
+        mockSolver.verifyEntityAdded(visit);
         assertThat(solution.getVisitList()).containsExactly(visit);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/ChangeVehicleCapacityTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/ChangeVehicleCapacityTest.java
@@ -17,14 +17,13 @@
 package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
+import org.optaweb.vehiclerouting.plugin.planner.MockSolver;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicleFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
+import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
 class ChangeVehicleCapacityTest {
 
@@ -32,18 +31,18 @@ class ChangeVehicleCapacityTest {
     void change_vehicle_capacity() {
         int oldCapacity = 100;
         int newCapacity = 50;
-        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
+
+        MockSolver<VehicleRoutingSolution> mockSolver = MockSolver.build(SolutionFactory.emptySolution());
 
         PlanningVehicle workingVehicle = PlanningVehicleFactory.testVehicle(1, oldCapacity);
         PlanningVehicle changeVehicle = PlanningVehicleFactory.testVehicle(2, newCapacity);
 
-        mockProblemChangeDirector.whenLookingUp(changeVehicle).thenReturn(workingVehicle);
+        mockSolver.whenLookingUp(changeVehicle).thenReturn(workingVehicle);
 
         // do change
-        ChangeVehicleCapacity changeVehicleCapacity = new ChangeVehicleCapacity(changeVehicle);
-        changeVehicleCapacity.doChange(SolutionFactory.emptySolution(), mockProblemChangeDirector);
+        mockSolver.addProblemChange(new ChangeVehicleCapacity(changeVehicle));
 
         assertThat(workingVehicle.getCapacity()).isEqualTo(newCapacity);
-        verify(mockProblemChangeDirector).changeProblemProperty(same(changeVehicle), any());
+        mockSolver.verifyProblemPropertyChanged(changeVehicle);
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/ChangeVehicleCapacityTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/ChangeVehicleCapacityTest.java
@@ -17,51 +17,33 @@
 package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicleFactory;
-import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
+import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 
-@ExtendWith(MockitoExtension.class)
 class ChangeVehicleCapacityTest {
-
-    @Mock
-    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
 
     @Test
     void change_vehicle_capacity() {
         int oldCapacity = 100;
         int newCapacity = 50;
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
 
         PlanningVehicle workingVehicle = PlanningVehicleFactory.testVehicle(1, oldCapacity);
         PlanningVehicle changeVehicle = PlanningVehicleFactory.testVehicle(2, newCapacity);
 
-        when(scoreDirector.lookUpWorkingObject(changeVehicle)).thenReturn(workingVehicle);
+        mockProblemChangeDirector.whenLookingUp(changeVehicle).thenReturn(workingVehicle);
 
         // do change
         ChangeVehicleCapacity changeVehicleCapacity = new ChangeVehicleCapacity(changeVehicle);
-        changeVehicleCapacity.doChange(scoreDirector);
+        changeVehicleCapacity.doChange(SolutionFactory.emptySolution(), mockProblemChangeDirector);
 
         assertThat(workingVehicle.getCapacity()).isEqualTo(newCapacity);
-
-        verify(scoreDirector).beforeProblemPropertyChanged(workingVehicle);
-        verify(scoreDirector).afterProblemPropertyChanged(workingVehicle);
-        verify(scoreDirector).triggerVariableListeners();
-    }
-
-    @Test
-    void fail_fast_if_working_object_is_null() {
-        ChangeVehicleCapacity changeVehicleCapacity = new ChangeVehicleCapacity(PlanningVehicleFactory.testVehicle(1));
-        assertThatIllegalStateException()
-                .isThrownBy(() -> changeVehicleCapacity.doChange(scoreDirector))
-                .withMessageContaining("working copy of");
+        verify(mockProblemChangeDirector).changeProblemProperty(same(changeVehicle), any());
     }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicleTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVehicleTest.java
@@ -18,18 +18,14 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory.testVisit;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningDepot;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningLocationFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicle;
@@ -38,11 +34,7 @@ import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-@ExtendWith(MockitoExtension.class)
 class RemoveVehicleTest {
-
-    @Mock
-    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
 
     @Test
     void remove_vehicle() {
@@ -59,8 +51,7 @@ class RemoveVehicleTest {
                 depot,
                 Arrays.asList(firstVisit, lastVisit));
 
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
-        when(scoreDirector.lookUpWorkingObject(removedVehicle)).thenReturn(removedVehicle);
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
 
         // V -> first -> last
         removedVehicle.setNextVisit(firstVisit);
@@ -72,19 +63,15 @@ class RemoveVehicleTest {
 
         // do change
         RemoveVehicle removeVehicle = new RemoveVehicle(removedVehicle);
-        removeVehicle.doChange(scoreDirector);
+        removeVehicle.doChange(solution, mockProblemChangeDirector);
 
         assertThat(firstVisit.getPreviousStandstill()).isNull();
         assertThat(lastVisit.getPreviousStandstill()).isNull();
         assertThat(solution.getVehicleList()).containsExactly(otherVehicle);
 
-        verify(scoreDirector).beforeVariableChanged(firstVisit, "previousStandstill");
-        verify(scoreDirector).afterVariableChanged(firstVisit, "previousStandstill");
-        verify(scoreDirector).beforeVariableChanged(lastVisit, "previousStandstill");
-        verify(scoreDirector).afterVariableChanged(lastVisit, "previousStandstill");
-        verify(scoreDirector).beforeProblemFactRemoved(removedVehicle);
-        verify(scoreDirector).afterProblemFactRemoved(removedVehicle);
-        verify(scoreDirector).triggerVariableListeners();
+        verify(mockProblemChangeDirector).changeVariable(same(firstVisit), eq("previousStandstill"), any());
+        verify(mockProblemChangeDirector).changeVariable(same(lastVisit), eq("previousStandstill"), any());
+        verify(mockProblemChangeDirector).removeProblemFact(same(removedVehicle), any());
     }
 
     @Test
@@ -101,22 +88,13 @@ class RemoveVehicleTest {
                 depot,
                 Collections.emptyList());
 
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
-        when(scoreDirector.lookUpWorkingObject(removedVehicle)).thenReturn(removedVehicle);
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
 
         // do change
         RemoveVehicle removeVehicle = new RemoveVehicle(removedVehicle);
         assertThatIllegalStateException()
-                .isThrownBy(() -> removeVehicle.doChange(scoreDirector))
+                .isThrownBy(() -> removeVehicle.doChange(solution, mockProblemChangeDirector))
                 .withMessageMatching(".*List .*" + wrongId + ".* doesn't contain the working.*" + removedId + ".*");
     }
 
-    @Test
-    void fail_fast_if_working_object_is_null() {
-        when(scoreDirector.getWorkingSolution()).thenReturn(SolutionFactory.emptySolution());
-
-        assertThatIllegalStateException()
-                .isThrownBy(() -> new RemoveVehicle(PlanningVehicleFactory.testVehicle(1)).doChange(scoreDirector))
-                .withMessageContaining("working copy of");
-    }
 }

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVisitTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/planner/change/RemoveVisitTest.java
@@ -18,30 +18,21 @@ package org.optaweb.vehiclerouting.plugin.planner.change;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVehicleFactory.testVehicle;
 import static org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisitFactory.testVisit;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.optaplanner.core.api.score.director.ScoreDirector;
+import org.optaplanner.test.api.solver.change.MockProblemChangeDirector;
 import org.optaweb.vehiclerouting.plugin.planner.domain.PlanningVisit;
 import org.optaweb.vehiclerouting.plugin.planner.domain.SolutionFactory;
 import org.optaweb.vehiclerouting.plugin.planner.domain.VehicleRoutingSolution;
 
-@ExtendWith(MockitoExtension.class)
 class RemoveVisitTest {
-
-    @Mock
-    private ScoreDirector<VehicleRoutingSolution> scoreDirector;
 
     @Test
     void remove_last_visit() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
 
         PlanningVisit removedVisit = testVisit(1);
         PlanningVisit otherVisit = testVisit(2);
@@ -53,23 +44,20 @@ class RemoveVisitTest {
         otherVisit.setNextVisit(removedVisit);
         removedVisit.setPreviousStandstill(otherVisit);
 
-        when(scoreDirector.lookUpWorkingObject(removedVisit)).thenReturn(removedVisit);
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
+        mockProblemChangeDirector.whenLookingUp(removedVisit).thenReturn(removedVisit);
 
         // do change
         RemoveVisit removeVisit = new RemoveVisit(removedVisit);
-        removeVisit.doChange(scoreDirector);
+        removeVisit.doChange(solution, mockProblemChangeDirector);
 
-        verify(scoreDirector).beforeEntityRemoved(removedVisit);
-        verify(scoreDirector).afterEntityRemoved(removedVisit);
+        verify(mockProblemChangeDirector).removeEntity(same(removedVisit), any());
         assertThat(solution.getVisitList()).containsExactly(otherVisit);
-
-        verify(scoreDirector).triggerVariableListeners();
     }
 
     @Test
     void remove_middle_visit() {
         VehicleRoutingSolution solution = SolutionFactory.emptySolution();
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
 
         PlanningVisit firstVisit = testVisit(1);
         PlanningVisit middleVisit = testVisit(2);
@@ -86,24 +74,23 @@ class RemoveVisitTest {
         lastVisit.setPreviousStandstill(middleVisit);
 
         PlanningVisit removedVisit = testVisit(2);
-        when(scoreDirector.lookUpWorkingObject(removedVisit)).thenReturn(middleVisit);
+
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
+        mockProblemChangeDirector.whenLookingUp(removedVisit).thenReturn(middleVisit);
 
         // do change
         RemoveVisit removeVisit = new RemoveVisit(removedVisit);
-        removeVisit.doChange(scoreDirector);
+        removeVisit.doChange(solution, mockProblemChangeDirector);
 
-        verify(scoreDirector).beforeVariableChanged(lastVisit, "previousStandstill");
-        verify(scoreDirector).afterVariableChanged(lastVisit, "previousStandstill");
-        verify(scoreDirector).beforeEntityRemoved(middleVisit);
-        verify(scoreDirector).afterEntityRemoved(middleVisit);
+        verify(mockProblemChangeDirector).changeVariable(same(lastVisit), eq("previousStandstill"), any());
+        verify(mockProblemChangeDirector).removeEntity(same(removedVisit), any());
+
         assertThat(solution.getVisitList())
                 .hasSize(2)
                 .containsOnly(firstVisit, lastVisit);
 
         // V -> first -> removed -> last
         assertThat(lastVisit.getPreviousStandstill()).isEqualTo(firstVisit);
-
-        verify(scoreDirector).triggerVariableListeners();
     }
 
     @Test
@@ -118,22 +105,13 @@ class RemoveVisitTest {
         removedVisit.setNextVisit(wrongVisit);
         solution.getVisitList().add(wrongVisit);
 
-        when(scoreDirector.getWorkingSolution()).thenReturn(solution);
-        when(scoreDirector.lookUpWorkingObject(removedVisit)).thenReturn(removedVisit);
+        MockProblemChangeDirector mockProblemChangeDirector = spy(new MockProblemChangeDirector());
+        mockProblemChangeDirector.whenLookingUp(removedVisit).thenReturn(removedVisit);
 
         // do change
         RemoveVisit removeVisit = new RemoveVisit(removedVisit);
         assertThatIllegalStateException()
-                .isThrownBy(() -> removeVisit.doChange(scoreDirector))
+                .isThrownBy(() -> removeVisit.doChange(solution, mockProblemChangeDirector))
                 .withMessageMatching(".*List .*" + wrongId + ".* doesn't contain the working.*" + removedId + ".*");
-    }
-
-    @Test
-    void fail_fast_if_working_object_is_null() {
-        when(scoreDirector.getWorkingSolution()).thenReturn(SolutionFactory.emptySolution());
-
-        assertThatIllegalStateException()
-                .isThrownBy(() -> new RemoveVisit(testVisit(0)).doChange(scoreDirector))
-                .withMessageContaining("working copy of");
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2541

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1703
https://github.com/kiegroup/optaplanner-quickstarts/pull/259
https://github.com/kiegroup/optaweb-vehicle-routing/pull/635

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>
