### PR TITLE
[DROOLS-6769] upgrade protobuf to version 3.17.3

### DIFF
--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouterTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouterTest.java
@@ -33,7 +33,7 @@ import org.optaweb.vehiclerouting.service.region.BoundingBox;
 
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
-import com.graphhopper.PathWrapper;
+import com.graphhopper.ResponsePath;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.PointList;
@@ -50,7 +50,7 @@ class GraphHopperRouterTest {
     @Mock
     private GHResponse ghResponse;
     @Mock
-    private PathWrapper pathWrapper;
+    private ResponsePath responsePath;
     @Mock
     private GraphHopperStorage graphHopperStorage;
 
@@ -59,7 +59,7 @@ class GraphHopperRouterTest {
     }
 
     private void whenBestReturnPath() {
-        when(ghResponse.getBest()).thenReturn(pathWrapper);
+        when(ghResponse.getBest()).thenReturn(responsePath);
     }
 
     @Test
@@ -68,7 +68,7 @@ class GraphHopperRouterTest {
         whenRouteReturnResponse();
         whenBestReturnPath();
         long travelTimeMillis = 135 * 60 * 60 * 1000;
-        when(pathWrapper.getTime()).thenReturn(travelTimeMillis);
+        when(responsePath.getTime()).thenReturn(travelTimeMillis);
 
         // act & assert
         assertThat(new GraphHopperRouter(graphHopper).travelTimeMillis(from, to)).isEqualTo(travelTimeMillis);
@@ -94,7 +94,7 @@ class GraphHopperRouterTest {
         // arrange
         whenRouteReturnResponse();
         whenBestReturnPath();
-        when(pathWrapper.getPoints()).thenReturn(pointList);
+        when(responsePath.getPoints()).thenReturn(pointList);
 
         Coordinates coordinates1 = Coordinates.valueOf(1, 1);
         Coordinates coordinates2 = Coordinates.valueOf(Math.E, Math.PI);

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouterTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/routing/GraphHopperRouterTest.java
@@ -33,7 +33,7 @@ import org.optaweb.vehiclerouting.service.region.BoundingBox;
 
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
-import com.graphhopper.ResponsePath;
+import com.graphhopper.PathWrapper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.PointList;
@@ -50,7 +50,7 @@ class GraphHopperRouterTest {
     @Mock
     private GHResponse ghResponse;
     @Mock
-    private ResponsePath responsePath;
+    private PathWrapper pathWrapper;
     @Mock
     private GraphHopperStorage graphHopperStorage;
 
@@ -59,7 +59,7 @@ class GraphHopperRouterTest {
     }
 
     private void whenBestReturnPath() {
-        when(ghResponse.getBest()).thenReturn(responsePath);
+        when(ghResponse.getBest()).thenReturn(pathWrapper);
     }
 
     @Test
@@ -68,7 +68,7 @@ class GraphHopperRouterTest {
         whenRouteReturnResponse();
         whenBestReturnPath();
         long travelTimeMillis = 135 * 60 * 60 * 1000;
-        when(responsePath.getTime()).thenReturn(travelTimeMillis);
+        when(pathWrapper.getTime()).thenReturn(travelTimeMillis);
 
         // act & assert
         assertThat(new GraphHopperRouter(graphHopper).travelTimeMillis(from, to)).isEqualTo(travelTimeMillis);
@@ -94,7 +94,7 @@ class GraphHopperRouterTest {
         // arrange
         whenRouteReturnResponse();
         whenBestReturnPath();
-        when(responsePath.getPoints()).thenReturn(pointList);
+        when(pathWrapper.getPoints()).thenReturn(pointList);
 
         Coordinates coordinates1 = Coordinates.valueOf(1, 1);
         Coordinates coordinates2 = Coordinates.valueOf(Math.E, Math.PI);

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
     <jacoco.agent.argLine/>
     <version.com.h2database>1.4.199</version.com.h2database>
     <version.org.mockito>3.1.0</version.org.mockito>
+    <!-- Override protobuf version from Quarkus to make it compatible with GraphHopper. -->
+    <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
   </properties>
 
   <dependencyManagement>
@@ -96,7 +98,7 @@
       <dependency>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-reader-osm</artifactId>
-        <version>2.4</version>
+        <version>0.13.0-pre13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-reader-osm</artifactId>
-        <version>0.13.0-pre13</version>
+        <version>2.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Trying to upgrade protobuf caused this exception
```
Caused by: java.lang.UnsupportedOperationException
	at org.openstreetmap.osmosis.osmbinary.Fileformat$BlobHeader.dynamicMethod(Fileformat.java:1430)
	at com.google.protobuf.GeneratedMessageLite.dynamicMethod(GeneratedMessageLite.java:256)
```
The problem is explained [here](https://discuss.graphhopper.com/t/failure-to-read-pbf-at-startup-not-supporting-message-info/5448/7) and I solved it also upgrading `graphhopper` to the latest stable version. As reported [here](https://github.com/graphhopper/graphhopper/blob/master/CHANGELOG.md#10-22-may-2020) this also required to change `PathWrapper` into `ResponsePath`.
