### PR TITLE
[7.x] RHPAM-4111: Update dependencies to match Spring Boot 2.4.9 and fix CORS configuration

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketConfig.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketConfig.java
@@ -18,6 +18,7 @@ package org.optaweb.vehiclerouting.plugin.websocket;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -39,7 +40,7 @@ class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // for the WebSocket handshake.
         registry
                 .addEndpoint("/vrp-websocket")
-                .setAllowedOrigins("*")
+                .setAllowedOriginPatterns(CorsConfiguration.ALL)
                 .withSockJS();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,8 @@
     <!-- Define JaCoCo agent argLine property to avoid Surefire failure when JaCoCo is not enabled. -->
     <jacoco.agent.argLine/>
     <version.com.h2database>1.4.199</version.com.h2database>
-    <version.org.mockito>3.1.0</version.org.mockito>
+    <version.org.junit>5.7.2</version.org.junit>
+    <version.org.mockito>3.6.28</version.org.mockito>
     <!-- Override protobuf version from Quarkus to make it compatible with GraphHopper. -->
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
   </properties>


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/RHPAM-4111

### Referenced pull requests
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1872
- https://github.com/kiegroup/droolsjbpm-integration/pull/2693
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/641
- https://github.com/kiegroup/optaweb-employee-rostering/pull/755

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>
