### PR TITLE
PLANNER-2465: Run SonarCloud analysis after push to main

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,53 @@
+# Runs SonarCloud analysis of the main branch after a PR is merged.
+name: SonarCloud analysis
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'LICENSE*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '**.md'
+      - '**.adoc'
+      - '**.txt'
+      - 'runOnOpenShift.sh'
+      - 'runLocally.sh'
+      - '.ci/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sonarcloud-analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven to measure code coverage
+        run: mvn -B --fail-at-end clean install -Prun-code-coverage
+      - name: Run SonarCloud analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: mvn -B --fail-at-end validate -Psonarcloud-analysis -Dsonar.login=${{ env.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
Copy-pasted from https://github.com/kiegroup/optaplanner/blob/fb2395c33ed9d6b63954e2a040429e494f835926/.github/workflows/sonarcloud.yml with some minor cleanup:

```diff
1,2c1,2
< # Runs the SonarCloud analysis of the optaplanner main branch after a PR is merged.
< name: OptaPlanner SonarCloud Analysis
---
> # Runs SonarCloud analysis of the main branch after a PR is merged.
> name: SonarCloud analysis
9a10
>       - 'CODEOWNERS'
10a12
>       - '.gitattributes'
13,14c15,18
<       - '*.txt'
<       - '.ci/**'      
---
>       - '**.txt'
>       - 'runOnOpenShift.sh'
>       - 'runLocally.sh'
>       - '.ci/**'
49c53
<         run: mvn -B --fail-at-end validate -Psonarcloud-analysis -Dsonar.projectKey=org.optaplanner:optaplanner -Dsonar.login=${{ env.SONARCLOUD_TOKEN }}
---
>         run: mvn -B --fail-at-end validate -Psonarcloud-analysis -Dsonar.login=${{ env.SONARCLOUD_TOKEN }}
```

### JIRA
https://issues.redhat.com/browse/PLANNER-2465

### Referenced pull requests
https://github.com/kiegroup/optaweb-vehicle-routing/pull/642
https://github.com/kiegroup/optaweb-employee-rostering/pull/756

This repo already has `SONARCLOUD_TOKEN` set.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>
