### PR TITLE
PLANNER-2645: Use PostgreSQL when running on OpenShift

### DIFF
--- a/optaweb-vehicle-routing-backend/.dockerignore
+++ b/optaweb-vehicle-routing-backend/.dockerignore
@@ -2,4 +2,4 @@
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*
-!target/quarkus-app/*
+!target/quarkus-app*/*

--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -57,8 +57,18 @@
       <artifactId>quarkus-jdbc-h2</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <optional>true</optional>
     </dependency>
     <!-- Planner -->
     <dependency>
@@ -171,6 +181,27 @@
               <goal>generate-code</goal>
               <goal>generate-code-tests</goal>
             </goals>
+            <configuration>
+              <properties>
+                <quarkus.package.output-directory>quarkus-app-h2</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>com.h2database:h2::jar</quarkus.package.included-optional-dependencies>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>postgresql</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.profile>postgresql</quarkus.profile>
+                <quarkus.package.output-directory>quarkus-app-postgresql</quarkus.package.output-directory>
+                <quarkus.package.filter-optional-dependencies>true</quarkus.package.filter-optional-dependencies>
+                <quarkus.package.included-optional-dependencies>org.postgresql:postgresql::jar</quarkus.package.included-optional-dependencies>
+              </properties>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/optaweb-vehicle-routing-backend/src/main/docker/Dockerfile.jvm
+++ b/optaweb-vehicle-routing-backend/src/main/docker/Dockerfile.jvm
@@ -42,11 +42,13 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV APP_PERSISTENCE_H2_DIR=/deployments/local/db
+ARG QUARKUS_APP_BUILD_QUALIFIER=h2
 # We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001 target/quarkus-app/*.jar /deployments/
-COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
-COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=1001 target/quarkus-app-${QUARKUS_APP_BUILD_QUALIFIER}/lib/ /deployments/lib/
+COPY --chown=1001 target/quarkus-app-${QUARKUS_APP_BUILD_QUALIFIER}/*.jar /deployments/
+COPY --chown=1001 target/quarkus-app-${QUARKUS_APP_BUILD_QUALIFIER}/app/ /deployments/app/
+COPY --chown=1001 target/quarkus-app-${QUARKUS_APP_BUILD_QUALIFIER}/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 1001

--- a/optaweb-vehicle-routing-backend/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application.properties
@@ -49,12 +49,12 @@ quarkus.log.category."org.jboss.resteasy".level=${LOG_LEVEL_RESTEASY:INFO}
 # Datasource
 ############
 
-# [Postgres] - recommended for production
-%postgres.quarkus.datasource.db-kind=postgresql
-%postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
-%postgres.quarkus.datasource.username=${DATABASE_USER}
-%postgres.quarkus.datasource.password=${DATABASE_PASSWORD}
-%postgres.quarkus.hibernate-orm.database.generation=update
+# [PostgreSQL] - recommended for production
+%postgresql.quarkus.datasource.db-kind=postgresql
+%postgresql.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
+%postgresql.quarkus.datasource.username=${DATABASE_USER}
+%postgresql.quarkus.datasource.password=${DATABASE_PASSWORD}
+%postgresql.quarkus.hibernate-orm.database.generation=update
 
 # [Default] - works out of the box, good for development
 # - using an embedded DB with relative path: http://h2database.com/html/features.html#embedded_databases

--- a/optaweb-vehicle-routing-standalone/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-standalone/src/main/resources/application.properties
@@ -33,11 +33,11 @@ quarkus.datasource.username=sa
 quarkus.datasource.password=
 quarkus.hibernate-orm.database.generation=update
 
-%postgres.quarkus.datasource.db-kind=postgresql
-%postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
-%postgres.quarkus.datasource.username=${DATABASE_USER}
-%postgres.quarkus.datasource.password=${DATABASE_PASSWORD}
-%postgres.quarkus.hibernate-orm.database.generation=update
+%postgresql.quarkus.datasource.db-kind=postgresql
+%postgresql.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME:optaweb_vrp_database}
+%postgresql.quarkus.datasource.username=${DATABASE_USER}
+%postgresql.quarkus.datasource.password=${DATABASE_PASSWORD}
+%postgresql.quarkus.hibernate-orm.database.generation=update
 
 %cypress.app.region.country-codes=DE
 %cypress.app.routing.gh-dir=target/graphhopper

--- a/runOnOpenShift.sh
+++ b/runOnOpenShift.sh
@@ -175,7 +175,7 @@ oc new-app --name postgresql postgresql-persistent
 
 # Back end
 # -- binary build (upload local artifacts + Dockerfile)
-oc new-build --name backend --strategy=docker --binary
+oc new-build --name backend --strategy=docker --binary --build-arg QUARKUS_APP_BUILD_QUALIFIER=postgresql
 oc patch bc backend -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"src/main/docker/Dockerfile.jvm"}}}}'
 oc start-build backend --from-dir=${dir_backend} --follow
 # -- new app


### PR DESCRIPTION
1. Create two quarkus-maven-plugin executions that build quarkus-app-h2
   and quarkus-app-postgresql. See
   https://quarkus.io/guides/maven-tooling#maven-multi-build.
2. Add Dockerfile.jvm ARG that allows to choose from the two above.
3. By default, it builds an image with quarkus-app-h2. But
   runOnOpenShift.sh uses the ARG to choose quarkus-app-postgresql.

### JIRA
https://issues.redhat.com/browse/PLANNER-2645

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>
