### PR TITLE
Increase proxy read timeout for SSE endpoint to avoid frequent connection resets on OpenShift

### DIFF
--- a/optaweb-vehicle-routing-frontend/docker/default.conf
+++ b/optaweb-vehicle-routing-frontend/docker/default.conf
@@ -28,6 +28,7 @@ server {
         chunked_transfer_encoding off;
         proxy_buffering off;
         proxy_cache off;
+        proxy_read_timeout 40h; # Otherwise the connection will be closed after 60s.
     }
 
     #error_page  404              /404.html;

--- a/optaweb-vehicle-routing-frontend/docker/nginx.conf
+++ b/optaweb-vehicle-routing-frontend/docker/nginx.conf
@@ -28,10 +28,4 @@ http {
     #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
-
-    # https://www.nginx.com/blog/websocket-nginx/
-    map $http_upgrade $connection_upgrade {
-        default upgrade;
-        ''      close;
-    }
 }


### PR DESCRIPTION
See commit descriptions for explanation.

@dupliaka I've tested this on locally in CRC. I do not expect thorough verification. A simple ack will do in this case.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>
