### PR TITLE
bumped up to next 8.20.0-SNAPSHOT

### DIFF
--- a/optaweb-vehicle-routing-backend/pom.xml
+++ b/optaweb-vehicle-routing-backend/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.optaweb.vehiclerouting</groupId>
     <artifactId>optaweb-vehicle-routing</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaweb-vehicle-routing-backend</artifactId>

--- a/optaweb-vehicle-routing-distribution/pom.xml
+++ b/optaweb-vehicle-routing-distribution/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.optaweb.vehiclerouting</groupId>
     <artifactId>optaweb-vehicle-routing</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaweb-vehicle-routing-distribution</artifactId>

--- a/optaweb-vehicle-routing-docs/pom.xml
+++ b/optaweb-vehicle-routing-docs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.optaweb.vehiclerouting</groupId>
     <artifactId>optaweb-vehicle-routing</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaweb-vehicle-routing-docs</artifactId>

--- a/optaweb-vehicle-routing-frontend/pom.xml
+++ b/optaweb-vehicle-routing-frontend/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.optaweb.vehiclerouting</groupId>
     <artifactId>optaweb-vehicle-routing</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaweb-vehicle-routing-frontend</artifactId>

--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.optaweb.vehiclerouting</groupId>
     <artifactId>optaweb-vehicle-routing</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaweb-vehicle-routing-standalone</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->



### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

- https://github.com/kiegroup/drools/pull/4286
- https://github.com/kiegroup/optaplanner/pull/1907
- https://github.com/kiegroup/optaplanner-quickstarts/pull/316
- https://github.com/kiegroup/optaweb-employee-rostering/pull/784
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/674
- https://github.com/kiegroup/kogito-apps/pull/1291
- https://github.com/kiegroup/kogito-examples/pull/1205
- https://github.com/kiegroup/kogito-runtimes/pull/2121

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
