### PR TITLE
[7.59.x] BXMSPROD-1673 spring-webmvc/spring-framework 5.3.18. spring-boot to 2.6.6

### DIFF
--- a/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketConfig.java
+++ b/optaweb-vehicle-routing-backend/src/main/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketConfig.java
@@ -18,6 +18,7 @@ package org.optaweb.vehiclerouting.plugin.websocket;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -39,7 +40,7 @@ class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // for the WebSocket handshake.
         registry
                 .addEndpoint("/vrp-websocket")
-                .setAllowedOrigins("*")
+                .setAllowedOriginPatterns(CorsConfiguration.ALL)
                 .withSockJS();
     }
 

--- a/optaweb-vehicle-routing-backend/src/main/resources/application-dev-cypress.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application-dev-cypress.properties
@@ -28,3 +28,5 @@ spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 # H2 console is enabled in the default profile.
 # You can connect to H2 console and examine DB contents at http://localhost:8080/h2-console/.
 # Enter "JDBC URL: jdbc:h2:mem:test" and click "Connect".
+
+spring.jpa.hibernate.naming.physical-strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy

--- a/optaweb-vehicle-routing-backend/src/main/resources/application-production.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application-production.properties
@@ -21,6 +21,7 @@ spring.datasource.password=${DATABASE_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 # https://stackoverflow.com/questions/43905119/postgres-error-method-org-postgresql-jdbc-pgconnection-createclob-is-not-imple
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.hibernate.naming.physical-strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
 
 # Disable H2 console enabled in the default profile
 spring.h2.console.enabled=false

--- a/optaweb-vehicle-routing-backend/src/main/resources/application.properties
+++ b/optaweb-vehicle-routing-backend/src/main/resources/application.properties
@@ -37,6 +37,7 @@ spring.datasource.url=jdbc:h2:file:${app.persistence.h2-dir:./local/db}/${app.pe
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.naming.physical-strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
 
 # Turn off deferred bootstrap mode. This is a workaround for https://github.com/spring-projects/spring-boot/issues/24249.
 # What is JPA repository bootstrap mode: https://docs.spring.io/spring-data/jpa/docs/2.4.3/reference/html/#jpa.bootstrap-mode.

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorMessageSenderTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/plugin/websocket/WebSocketErrorMessageSenderTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.service.error.ErrorMessage;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -29,7 +29,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 class WebSocketErrorMessageSenderTest {
 
     @Test
-    void should_send_consumed_message_over_websocket(@Mock SimpMessagingTemplate webSocket) {
+    void should_send_consumed_message_over_websocket() {
+        SimpMessagingTemplate webSocket = Mockito.mock(SimpMessagingTemplate.class);
         ErrorMessage message = ErrorMessage.of("id", "error");
         new WebSocketErrorMessageSender(webSocket).consumeMessage(message);
         verify(webSocket).convertAndSend(

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/error/ErrorListenerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,8 +33,9 @@ class ErrorListenerTest {
     private ArgumentCaptor<ErrorMessage> argumentCaptor;
 
     @Test
-    void should_pass_error_message_to_consumer(@Mock ErrorMessageConsumer errorMessageConsumer) {
+    void should_pass_error_message_to_consumer() {
         // arrange
+        ErrorMessageConsumer errorMessageConsumer = Mockito.mock(ErrorMessageConsumer.class);
         String text = "error";
         ErrorListener errorListener = new ErrorListener(errorMessageConsumer);
         // act

--- a/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
+++ b/optaweb-vehicle-routing-backend/src/test/java/org/optaweb/vehiclerouting/service/location/LocationServiceTest.java
@@ -20,11 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.optaweb.vehiclerouting.domain.Coordinates;
 import org.optaweb.vehiclerouting.domain.Location;
@@ -64,7 +61,8 @@ class LocationServiceTest {
     }
 
     @Test
-    void createLocation(@Mock DistanceMatrixRow matrixRow) {
+    void createLocation() {
+        DistanceMatrixRow matrixRow = Mockito.mock(DistanceMatrixRow.class);
         String description = "new location";
         when(repository.createLocation(coordinates, description)).thenReturn(location);
         when(distanceMatrix.addLocation(any())).thenReturn(matrixRow);
@@ -82,7 +80,8 @@ class LocationServiceTest {
     }
 
     @Test
-    void addLocation(@Mock DistanceMatrixRow matrixRow) {
+    void addLocation() {
+        DistanceMatrixRow matrixRow = Mockito.mock(DistanceMatrixRow.class);
         when(distanceMatrix.addLocation(any())).thenReturn(matrixRow);
         assertThat(locationService.addLocation(location)).isTrue();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1673

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1939
* https://github.com/kiegroup/optaplanner/pull/1920
* https://github.com/kiegroup/droolsjbpm-integration/pull/2764
* https://github.com/kiegroup/openshift-drools-hacep/pull/128
* https://github.com/kiegroup/optaweb-employee-rostering/pull/786
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/676

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
