### PR TITLE
Run docker and podman with current user UID

### DIFF
--- a/optaweb-vehicle-routing-standalone/pom.xml
+++ b/optaweb-vehicle-routing-standalone/pom.xml
@@ -167,25 +167,12 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>${container.runtime}</executable>
-              <workingDirectory>${project.parent.basedir}/${frontend.project.name}</workingDirectory>
+              <executable>${project.basedir}/run_cypress_tests.sh</executable>
               <arguments>
-                <argument>run</argument>
-                <argument>--network=host</argument> <!-- Cypress accesses UI running on the host. -->
-                <argument>--volume</argument>
-                <argument>${project.parent.basedir}/${frontend.project.name}:/e2e:Z</argument>
-                <argument>--workdir</argument>
-                <argument>/e2e</argument>
-                <argument>${user.flag}</argument>
-                <argument>${user.name.group}</argument>
-                <argument>--entrypoint</argument>
-                <argument>cypress</argument>
-                <argument>cypress/included:${version.cypress.docker}</argument>
-                <argument>run</argument> <!-- Executing cypress:run. -->
-                <argument>--project</argument>
-                <argument>.</argument>
-                <argument>--config</argument>
-                <argument>baseUrl=${application.url}</argument>
+                <argument>${container.runtime}</argument>
+                <argument>${maven.multiModuleProjectDirectory}${file.separator}${frontend.project.name}</argument>
+                <argument>${version.cypress.docker}</argument>
+                <argument>${application.port}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -272,19 +259,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>docker</id>
-      <activation>
-        <property>
-          <name>container.runtime</name>
-          <value>docker</value>
-        </property>
-      </activation>
-      <properties>
-        <user.flag>--user</user.flag>
-        <user.name.group>1000:1000</user.name.group>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/optaweb-vehicle-routing-standalone/run_cypress_tests.sh
+++ b/optaweb-vehicle-routing-standalone/run_cypress_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+readonly CONTAINER_RUNTIME=$1
+readonly FRONTEND_PROJECT_PATH=$2
+readonly VERSION_CYPRESS=$3
+readonly APPLICATION_PORT=$4
+
+user_command="--user  $(id -u):$(id -g)"
+
+if [[ "$CONTAINER_RUNTIME" == "podman" ]]
+then
+    user_command="${user_command} --userns=keep-id"
+fi
+
+$CONTAINER_RUNTIME run --network=host \
+                          -v $FRONTEND_PROJECT_PATH:/e2e:Z \
+                          $user_command \
+                          -w /e2e --entrypoint cypress docker.io/cypress/included:$VERSION_CYPRESS \
+                          run --project . --config baseUrl=http://localhost:$APPLICATION_PORT


### PR DESCRIPTION
To get UID I need to get to bash so I isolated cypress tests in run_cypress_tests.sh
That is needed since if I just use 1000:1000 then the files that gets created in the process of the tests (video + snapshot picture) will be created with the root id and group owning. This fails cleanup stage. So I need to follow the uid of Jenkins to make it possible to be removed works for podman and docker

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
 https://issues.redhat.com/browse/PLANNER-2695

### Referenced pull requests
- https://github.com/kiegroup/optaweb-employee-rostering/pull/799


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] LTS</b>
<!--
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
