### PR TITLE
[8.13.x] KOGITO-7356 Do not use master node in pipelines

### DIFF
--- a/.ci/jenkins/dsl/Jenkinsfile.seed
+++ b/.ci/jenkins/dsl/Jenkinsfile.seed
@@ -1,7 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
 seed_generation = null
-node('master') {
+node('kie-rhel8 && !master') {
     dir("${SEED_REPO}") {
         checkout(githubscm.resolveRepository("${SEED_REPO}", "${SEED_AUTHOR}", "${SEED_BRANCH}", false))
         seed_generation = load "${SEED_SCRIPTS_FILEPATH}"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7356

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/484
- https://github.com/kiegroup/drools/pull/4446
- https://github.com/kiegroup/kogito-runtimes/pull/2252
- https://github.com/kiegroup/kogito-apps/pull/1375
- https://github.com/kiegroup/kogito-examples/pull/1285
- https://github.com/kiegroup/kogito-images/pull/1275
- https://github.com/kiegroup/kogito-operator/pull/1204
- https://github.com/kiegroup/optaplanner/pull/2023
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/708
- https://github.com/kiegroup/optaweb-employee-rostering/pull/826
- https://github.com/kiegroup/optaplanner-quickstarts/pull/352