### PR TITLE
Rename unused function parameters

### DIFF
--- a/optaweb-vehicle-routing-frontend/src/store/demo/operations.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/demo/operations.ts
@@ -5,7 +5,7 @@ import { RequestDemoAction } from './types';
 export const { finishLoading } = actions;
 
 export const requestDemo: ThunkCommandFactory<string, RequestDemoAction> = (
-  (name) => (dispatch, getState, client) => {
+  (name) => (dispatch, _getState, client) => {
     dispatch(actions.requestDemo(name));
     client.loadDemo(name);
   });

--- a/optaweb-vehicle-routing-frontend/src/store/route/operations.ts
+++ b/optaweb-vehicle-routing-frontend/src/store/route/operations.ts
@@ -13,41 +13,41 @@ import {
 export const { updateRoute } = actions;
 
 export const addLocation: ThunkCommandFactory<LatLngWithDescription, AddLocationAction> = (
-  (location) => (dispatch, getState, client) => {
+  (location) => (dispatch, _getState, client) => {
     dispatch(actions.addLocation(location));
     client.addLocation(location);
   });
 
 export const deleteLocation: ThunkCommandFactory<number, DeleteLocationAction> = (
-  (locationId) => (dispatch, getState, client) => {
+  (locationId) => (dispatch, _getState, client) => {
     dispatch(actions.deleteLocation(locationId));
     client.deleteLocation(locationId);
   });
 
 export const addVehicle: ThunkCommandFactory<void, AddVehicleAction> = (
-  () => (dispatch, getState, client) => {
+  () => (dispatch, _getState, client) => {
     dispatch(actions.addVehicle());
     client.addVehicle();
   });
 
 export const deleteVehicle: ThunkCommandFactory<number, DeleteVehicleAction> = (
-  (vehicleId) => (dispatch, getState, client) => {
+  (vehicleId) => (dispatch, _getState, client) => {
     dispatch(actions.deleteVehicle(vehicleId));
     client.deleteVehicle(vehicleId);
   });
 
 export const deleteAnyVehicle: ThunkCommandFactory<void, never> = (
-  () => (dispatch, getState, client) => {
+  () => (_dispatch, _getState, client) => {
     client.deleteAnyVehicle();
   });
 
 export const changeVehicleCapacity: ThunkCommandFactory<VehicleCapacity, never> = (
-  ({ vehicleId, capacity }: VehicleCapacity) => (dispatch, getState, client) => {
+  ({ vehicleId, capacity }: VehicleCapacity) => (_dispatch, _getState, client) => {
     client.changeVehicleCapacity(vehicleId, capacity);
   });
 
 export const clearRoute: ThunkCommandFactory<void, ClearRouteAction> = (
-  () => (dispatch, getState, client) => {
+  () => (dispatch, _getState, client) => {
     dispatch(actions.clearRoute());
     client.clear();
   });


### PR DESCRIPTION
Detected by SonarCloud.

"Unused parameters are misleading. ...the rule ignores all parameters
whose name starts with an underscore (_). This is a common practice to
acknowledge the fact that some parameter is unused (e.g. in TypeScript
compiler)."

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job:  
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job:  
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>

<!-- - for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] mandrel</b> -->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
