### PR TITLE
PLANNER-2822 Remove Mandrel LTS check

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -31,6 +31,7 @@ Map getMultijobPRConfig() {
 List environments = Environment.getActiveEnvironments(this)
 environments.retainAll { it != Environment.NATIVE } // There is no requirement for Native support.
 environments.retainAll { it != Environment.MANDREL } // There is no requirement for Native Mandrel support.
+environments.retainAll { it != Environment.MANDREL_LTS } // There is no requirement for Native Mandrel LTS support.
 KogitoJobUtils.createPerEnvPerRepoPRJobs(this, environments) { jobFolder -> getMultijobPRConfig() }
 
 // Init branch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -72,22 +72,6 @@ How to retest this PR or trigger a specific build:
 - for a <b>specific quarkus main check</b>  
   Run checks against Quarkus main branch  
   Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>
-
-<!-- - for <b>native checks</b>  
-  Run native checks  
-  Please add comment: <b>Jenkins run native</b>
-
-- for a <b>specific native check</b>  
-  Run native checks 
-  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>
-
-- for <b>mandrel checks</b>  
-  Run native checks against Mandrel image
-  Please add comment: <b>Jenkins run mandrel</b>
-
-- for a <b>specific mandrel check</b>  
-  Run native checks against Mandrel image  
-  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] mandrel</b> -->
 </details>
 
 ### CI Status


### PR DESCRIPTION
- remove Mandrel LTS check as no native on optaweb

### JIRA

https://issues.redhat.com/browse/PLANNER-2822

### Referenced pull requests

- https://github.com/kiegroup/optaplanner/pull/2217
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/759
- https://github.com/kiegroup/optaplanner-quickstarts/pull/413
- https://github.com/kiegroup/kogito-pipelines/pull/641

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job:  
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job:  
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>

<!-- - for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] mandrel</b> -->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
