### PR TITLE
PLANNER-2829 Init branch becomes Setup branch

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -93,7 +93,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            sendNotification()
+            sendErrorNotification()
         }
         cleanup {
             script {
@@ -103,9 +103,10 @@ pipeline {
     }
 }
 
-void sendNotification() {
+void sendErrorNotification() {
     if (params.SEND_NOTIFICATION) {
-        mailer.sendMarkdownTestSummaryNotification('Init', "[${getBuildBranch()}] Optaweb Vehicle Routing", [env.OPTAPLANNER_CI_EMAIL_TO])
+        String additionalInfo = "**[${getBuildBranch()}] Optaweb Vehicle Routing - Setup branch**"
+        mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -12,6 +12,7 @@ import org.kie.jenkins.jobdsl.model.Environment
 import org.kie.jenkins.jobdsl.model.Folder
 import org.kie.jenkins.jobdsl.KogitoJobTemplate
 import org.kie.jenkins.jobdsl.KogitoJobUtils
+import org.kie.jenkins.jobdsl.Utils
 
 jenkins_path = '.ci/jenkins'
 
@@ -35,11 +36,11 @@ environments.retainAll { it != Environment.MANDREL_LTS } // There is no requirem
 KogitoJobUtils.createPerEnvPerRepoPRJobs(this, environments) { jobFolder -> getMultijobPRConfig() }
 
 // Init branch
-setupInitBranchJob()
+createSetupBranchJob()
 
 
-void setupInitBranchJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaweb-vehicle-routing', Folder.INIT_BRANCH, "${jenkins_path}/Jenkinsfile.init-branch", 'Optaweb Vehicle Routing Init Branch')
+void createSetupBranchJob() {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaweb-vehicle-routing', Folder.SETUP_BRANCH, "${jenkins_path}/Jenkinsfile.setup-branch", 'Optaweb Vehicle Routing Setup Branch')
     KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
         REPO_NAME: 'optaweb-vehicle-routing',
@@ -51,6 +52,8 @@ void setupInitBranchJob() {
         MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
         MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
         MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+
+        IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         parameters {


### PR DESCRIPTION
### JIRA

https://issues.redhat.com/browse/PLANNER-2829

### Referenced pull requests

- https://github.com/kiegroup/kogito-pipelines/pull/658
- https://github.com/kiegroup/optaplanner/pull/2255
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/774
- https://github.com/kiegroup/optaplanner-quickstarts/pull/437
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job:  
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job:  
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaweb-vehicle-routing] quarkus-branch</b>
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
