### PR TITLE
update npm to version 6.14.18

### DIFF
--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [11]
-        maven-version: ['3.8.1']
+        maven-version: ['3.8.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Full downstream build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,4 +57,4 @@ jobs:
         # Check that Git working tree is clean after running `npm install` via the frontend-maven-plugin.
         # The `git` command exits with 1 and fails the build if there are any uncommitted changes.
         run: git diff HEAD --exit-code
-        working-directory: kiegroup_optaweb_vehicle_routing/optaweb-vehicle-routing
+        working-directory: kiegroup_optaweb-vehicle-routing/optaweb-vehicle-routing

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java-version: [11, 17]
-        maven-version: ['3.8.1']
+        maven-version: ['3.8.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
     <version.frontend-maven-plugin>1.11.3</version.frontend-maven-plugin>
     <version.node>v12.16.2</version.node>
-    <version.npm>6.14.4</version.npm>
+    <version.npm>6.14.18</version.npm>
     <!-- Override protobuf version from Quarkus to make it compatible with GraphHopper. -->
     <protobuf-java.version>3.6.1</protobuf-java.version>
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>


### PR DESCRIPTION
The reason to try to update npm version here is that: Indy/PNC "sidecar" uses TLS v.1.3 and projects **optaweb-employee-rostering** and **optaweb-vehicle-routing** are using an old npm version and for some reason it seems they don't work reliably. So it means that we are having to rebuild those projects on PNC until they pass.

Maybe upgrading npm to a version that was released recently could fix that.

**Related PRs:**
- https://github.com/kiegroup/optaweb-employee-rostering/pull/887
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/861