### PR TITLE
[8.13.x][RHPAM-4700][CVE-2022-1471] Upgrade Jackson to 2.15.2 to make it work with SnakeYAML 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
     <version.frontend-maven-plugin>1.11.3</version.frontend-maven-plugin>
     <version.node>v12.16.2</version.node>
     <version.npm>6.14.18</version.npm>
+    <!-- Override protobuf version from Quarkus to make it compatible with SnakeYAML 2.0. -->
+    <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>
     <!-- Override protobuf version from Quarkus to make it compatible with GraphHopper. -->
     <protobuf-java.version>3.19.6</protobuf-java.version>
     <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
@@ -86,6 +88,13 @@
         <type>zip</type>
       </dependency>
       <!-- BOM imports -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.com.fasterxml.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-4700

No org.yaml:snakeyaml:jar:1.33.0 traces on optaweb* or kogito-examples projects after related PRs

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/9
- https://github.com/kiegroup/optaplanner/pull/25