### PR TITLE
Disable Sonarcloud analysis on 8.13.x

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -12,6 +12,10 @@ Map getMultijobPRConfig() {
             [
                 id: 'optaweb-vehicle-routing',
                 primary: true,
+                env : [
+                    // Disable Sonarcloud analysis.
+                    DISABLE_SONARCLOUD: true
+                ]
             ]
         ],
     ]


### PR DESCRIPTION
Because https://github.com/kiegroup/kogito-pipelines/blob/1.13.x/.ci/jenkins/Jenkinsfile.buildchain#L11.